### PR TITLE
Migration optimization

### DIFF
--- a/backend/fms_core/migrations/0016_v3_1_0.py
+++ b/backend/fms_core/migrations/0016_v3_1_0.py
@@ -44,7 +44,7 @@ def create_lineage_from_extracted_and_revisions(apps, schema_editor):
     extraction_protocol = protocol_model.objects.get(name="Extraction")
     extracted_samples_info = {}
 
-    for revision in revision_model.objects.filter(comment="Imported extracted samples from template.").iterator():
+    for revision in revision_model.objects.filter(comment="Imported extracted samples from template.").all():
         extracted_samples = version_model.objects.filter(revision_id=revision.id,
                                                          content_type__model="sample",
                                                          object_repr__icontains="(extracted, ")

--- a/backend/fms_core/migrations/0017_v3_1_0.py
+++ b/backend/fms_core/migrations/0017_v3_1_0.py
@@ -8,18 +8,23 @@ from ..utils import float_to_decimal
 
 def add_values_to_sample_volume(apps, schema_editor):
     Sample = apps.get_model("fms_core", "Sample")
-    for sample in Sample.objects.all():
+    samples = Sample.objects.all()
+    for sample in samples:
         sample.volume = float_to_decimal(sample.volume_history[-1]["volume_value"] if sample.volume_history else 0.0)
-        sample.save()
+        #sample.save()
+    Sample.objects.bulk_update(samples, ['volume'])
 
     Version = apps.get_model("reversion", "Version")
-    for version in Version.objects.filter(content_type__model="sample"):
+    versions = Version.objects.filter(content_type__model="sample")
+    for version in versions:
         data = json.loads(version.serialized_data)
         volume_history = data[0]["fields"]["volume_history"]
         volume = volume_history[-1]["volume_value"] if volume_history else 0.0
         data[0]["fields"]["volume"] = volume
         version.serialized_data = json.dumps(data)
-        version.save()
+        # version.save()
+
+    Version.objects.bulk_update(versions, ['serialized_data'])
 
 
 class Migration(migrations.Migration):

--- a/backend/fms_core/migrations/0017_v3_1_0.py
+++ b/backend/fms_core/migrations/0017_v3_1_0.py
@@ -8,24 +8,37 @@ from ..utils import float_to_decimal
 
 def add_values_to_sample_volume(apps, schema_editor):
     Sample = apps.get_model("fms_core", "Sample")
-    samples = Sample.objects.all()
-    for sample in samples:
+    for sample in Sample.objects.all():
         sample.volume = float_to_decimal(sample.volume_history[-1]["volume_value"] if sample.volume_history else 0.0)
-        #sample.save()
-    Sample.objects.bulk_update(samples, ['volume'])
+        sample.save()
 
+
+def handle_sample_versions(apps, schema_editor):
     Version = apps.get_model("reversion", "Version")
-    versions = Version.objects.filter(content_type__model="sample")
-    for version in versions:
+    SampleKind = apps.get_model("fms_core", "SampleKind")
+    sample_kind_ids_by_name = {sample_kind.name: sample_kind.id for sample_kind in SampleKind.objects.all()}
+
+    for version in Version.objects.filter(content_type__model="sample"):
         data = json.loads(version.serialized_data)
+
+        # Handle biospecimen type change to sample_kind_id
+        data[0]["fields"]["sample_kind"] = sample_kind_ids_by_name[data[0]["fields"]["biospecimen_type"]]
+        data[0]["fields"].pop("biospecimen_type", None)
+
+        # Change sample versions for creation dates
+        data[0]["fields"]["creation_date"] = data[0]["fields"]["reception_date"]
+        data[0]["fields"].pop("reception_date", None)
+
+        # Pop fields extracted_from and volume_used
+        data[0]["fields"].pop("extracted_from", None)
+        data[0]["fields"].pop("volume_used", None)
+
+        # Handle Volume History to Volume
         volume_history = data[0]["fields"]["volume_history"]
-        volume = volume_history[-1]["volume_value"] if volume_history else 0.0
-        data[0]["fields"]["volume"] = volume
+        data[0]["fields"]["volume"] = volume_history[-1]["volume_value"] if volume_history else 0.0
+
         version.serialized_data = json.dumps(data)
-        # version.save()
-
-    Version.objects.bulk_update(versions, ['serialized_data'])
-
+        version.save()
 
 class Migration(migrations.Migration):
 
@@ -48,7 +61,10 @@ class Migration(migrations.Migration):
             name='volume',
             field=models.DecimalField(decimal_places=3, help_text='Current volume of the sample, in µL. ', max_digits=20),
         ),
-        # TODO: deal with Sample.volume_history (for sample updates)
+        migrations.RunPython(
+            handle_sample_versions,
+            migrations.RunPython.noop
+        ),
         migrations.RemoveField(
             model_name='sample',
             name='volume_used',

--- a/backend/fms_core/migrations/0017_v3_1_0.py
+++ b/backend/fms_core/migrations/0017_v3_1_0.py
@@ -8,7 +8,7 @@ from ..utils import float_to_decimal
 
 def add_values_to_sample_volume(apps, schema_editor):
     Sample = apps.get_model("fms_core", "Sample")
-    for sample in Sample.objects.all():
+    for sample in Sample.objects.iterator():
         sample.volume = float_to_decimal(sample.volume_history[-1]["volume_value"] if sample.volume_history else 0.0)
         sample.save()
 
@@ -18,7 +18,7 @@ def handle_sample_versions(apps, schema_editor):
     SampleKind = apps.get_model("fms_core", "SampleKind")
     sample_kind_ids_by_name = {sample_kind.name: sample_kind.id for sample_kind in SampleKind.objects.all()}
 
-    for version in Version.objects.filter(content_type__model="sample"):
+    for version in Version.objects.filter(content_type__model="sample").iterator():
         data = json.loads(version.serialized_data)
 
         # Handle biospecimen type change to sample_kind_id


### PR DESCRIPTION
* I have read about other ways of optimizing the django orm queries, either by using bulk_update/bulk_create (which bypass the save()/presave/postsave methods in the models btw), or using iterator() instead of caching the whole queryset into the memory, but I did not have much proof of the efficiency when running our migration.

* The best I could do is to regroup all the versions modifications into a single operation rather than many. Going through the 80K Sample objects in Version were the slower steps, and we do not modify Sample Versions during the migration when making modifications to Sample objects anyways, so the order of operations does not really matter in our case. 

On my local machine, I was able to reduce the migration time from 4min30 to 2mins30, which is still a significant improvement imo.





