### PR TITLE
Tissue source optional

### DIFF
--- a/frontend/src/components/samples/SampleEditContent.js
+++ b/frontend/src/components/samples/SampleEditContent.js
@@ -201,7 +201,7 @@ const SampleEditContent = ({token, samplesByID, sampleKinds, add, update}) => {
               )}
             </Select>
           </Form.Item>
-          <Form.Item label="Tissue" {...props("tissue_source")} rules={isTissueEnabled ? requiredRules : undefined}>
+          <Form.Item label="Tissue" {...props("tissue_source")}>
             <Select allowClear disabled={!isTissueEnabled}>
               {TISSUE_SOURCE.map(type =>
                 <Option key={type} value={type}>{type}</Option>


### PR DESCRIPTION
Tested it with templates and in the backend where the tissue source is optional.
It appears that it only shows as required for DNA/RNA in the front-end form. 