### PR TITLE
Handle JSON fields in Sample Versions Diff

### DIFF
--- a/frontend/src/utils/renderSampleDiff.js
+++ b/frontend/src/utils/renderSampleDiff.js
@@ -28,7 +28,7 @@ export default function renderSampleDiff(oldVersion, newVersion, usersByID) {
   const items = Object.entries(deltas).map(([key, delta]) => {
     if (Array.isArray(delta))
       return renderArrayDelta(key, delta, oldVersion, newVersion, usersByID);
-    else if(delta.constructor == Object)
+    else if (delta.constructor == Object)
       return renderJSONDelta(key, delta, oldVersion, newVersion);
 
     return renderUnknownDelta(key, delta, oldVersion, newVersion);

--- a/frontend/src/utils/renderSampleDiff.js
+++ b/frontend/src/utils/renderSampleDiff.js
@@ -25,10 +25,11 @@ export default function renderSampleDiff(oldVersion, newVersion, usersByID) {
   if (deltas === undefined)
     return null;
 
-
   const items = Object.entries(deltas).map(([key, delta]) => {
     if (Array.isArray(delta))
       return renderArrayDelta(key, delta, oldVersion, newVersion, usersByID);
+    else if(delta.constructor == Object)
+      return renderJSONDelta(key, delta, oldVersion, newVersion);
 
     return renderUnknownDelta(key, delta, oldVersion, newVersion);
   });
@@ -46,6 +47,19 @@ function renderUnknownDelta(name, delta, oldVersion, newVersion) {
         <Tag color="red" >
           unknown modification (please report this): <code>{JSON.stringify(delta)}</code>
         </Tag>
+    </div>
+  );
+}
+
+function renderJSONDelta(key, delta, oldVersion, newVersion) {
+  const oldValue = oldVersion.fields[key].toString();
+  const newValue = newVersion.fields[key].toString();
+  return (
+    <div key={key}>
+      <code>{key}:</code>{' '}
+      <Tag color="red" style={removedStyle}>{oldValue}</Tag>
+      <SwapRightOutlined style={arrowStyle} />
+      <Tag color="green" className='diff__added'>{newValue}</Tag>
     </div>
   );
 }


### PR DESCRIPTION
This is mainly to accomodate the use of the 'Experimental group' field which is a JSON field. It would not render properly in the Sample Detail page, in the Versions box. 

PS: @UlysseFG  I could open another PR to have it merged to QC too if you want.. 