### PR TITLE
Revision endpoint for users

### DIFF
--- a/backend/fms_core/router.py
+++ b/backend/fms_core/router.py
@@ -12,6 +12,7 @@ from .viewsets import (
     UserViewSet,
     GroupViewSet,
     VersionViewSet,
+    RevisionViewSet,
 )
 
 __all__ = ["router"]
@@ -26,5 +27,6 @@ router.register(r"samples", SampleViewSet)
 router.register(r"individuals", IndividualViewSet)
 router.register(r"query", QueryViewSet, basename="query")
 router.register(r"versions", VersionViewSet)
+router.register(r"revisions", RevisionViewSet)
 router.register(r"users", UserViewSet)
 router.register(r"groups", GroupViewSet)

--- a/backend/fms_core/serializers.py
+++ b/backend/fms_core/serializers.py
@@ -1,8 +1,8 @@
 from django.contrib.auth.models import User, Group
 from rest_framework import serializers
-from reversion.models import Version
+from reversion.models import Version, Revision
 
-from .models import Container, Sample, Individual, Protocol, Process, ProcessMeasurement, SampleKind
+from .models import Container, Sample, Individual, Protocol, ProcessMeasurement, SampleKind
 
 
 __all__ = [
@@ -18,6 +18,7 @@ __all__ = [
     "SampleExportSerializer",
     "NestedSampleSerializer",
     "VersionSerializer",
+    "RevisionSerializer",
     "UserSerializer",
     "GroupSerializer",
 ]
@@ -156,6 +157,12 @@ class VersionSerializer(serializers.ModelSerializer):
         model = Version
         fields = "__all__"
         depth = 1
+
+
+class RevisionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Revision
+        fields = "__all__"
 
 
 class UserSerializer(serializers.ModelSerializer):

--- a/backend/fms_core/viewsets.py
+++ b/backend/fms_core/viewsets.py
@@ -10,7 +10,7 @@ from rest_framework import viewsets, status
 from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny, IsAuthenticated, DjangoModelPermissions
 from rest_framework.response import Response
-from reversion.models import Version
+from reversion.models import Version, Revision
 from tablib import Dataset
 from typing import Any, Dict, List, Tuple, Union
 
@@ -37,6 +37,7 @@ from .serializers import (
     NestedSampleSerializer,
     IndividualSerializer,
     VersionSerializer,
+    RevisionSerializer,
     UserSerializer,
     GroupSerializer,
 )
@@ -61,6 +62,7 @@ __all__ = [
     "UserViewSet",
     "GroupViewSet",
     "VersionViewSet",
+    "RevisionViewSet",
 ]
 
 
@@ -744,6 +746,14 @@ class VersionViewSet(viewsets.ReadOnlyModelViewSet):
         "revision__id": FK_FILTERS,
         "revision__date_created": DATE_FILTERS,
         "revision__user": ["exact"],
+    }
+
+
+class RevisionViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Revision.objects.all()
+    serializer_class = RevisionSerializer
+    filterset_fields = {
+        "user_id": FK_FILTERS,
     }
 
 

--- a/frontend/src/components/users/UsersDetailContent.js
+++ b/frontend/src/components/users/UsersDetailContent.js
@@ -68,6 +68,7 @@ const ReportsUserContent = ({canWrite, isFetching, usersError, usersByID, groups
   const history = useHistory();
   const {id} = useParams();
   const [expandedGroups, setExpandedGroups] = useState({});
+  const [isLoadRevisions, setIsLoadRevisions] = useState(false);
 
   const user = usersByID[id];
 
@@ -75,7 +76,8 @@ const ReportsUserContent = ({canWrite, isFetching, usersError, usersByID, groups
     get(id)
   }
 
-  if (user && !user.revisions && !user.isFetching) {
+  if (user && !user.isFetching && !isLoadRevisions) {
+    setIsLoadRevisions(true)
     setTimeout(() => listRevisions(user.id), 0);
   }
 

--- a/frontend/src/components/users/UsersDetailContent.js
+++ b/frontend/src/components/users/UsersDetailContent.js
@@ -219,7 +219,6 @@ function TimelineEntry({ revision, expandedGroups, setExpandedGroups, listVersio
     listVersions(revision.user, revision.id)
         .then(response => {
           setGroup(response.results)
-          console.log(response)
           setIsLoading(false)
         })
   }
@@ -261,9 +260,7 @@ function TimelineEntry({ revision, expandedGroups, setExpandedGroups, listVersio
 
 function renderTimelineLabel(revision) {
   return (
-      <div>
-        <Text type="secondary">{dateToString(revision.date_created)}</Text>
-      </div>
+      <Text type="secondary">{dateToString(revision.date_created)}</Text>
   )
 }
 

--- a/frontend/src/components/users/UsersDetailContent.js
+++ b/frontend/src/components/users/UsersDetailContent.js
@@ -3,21 +3,15 @@ import {connect} from "react-redux";
 import {useHistory, useParams} from "react-router-dom";
 import {
   compose,
-  groupBy,
   map,
   path,
   reduce,
-  reverse,
-  sortBy,
-  values,
 } from "rambda";
 import {set} from "object-path-immutable";
 import {
   Button,
   Card,
-  Col,
   Descriptions,
-  Row,
   Space,
   Tag,
   Table,
@@ -25,8 +19,6 @@ import {
   Typography,
 } from "antd";
 import {
-  ArrowsAltOutlined,
-  ShrinkOutlined,
   MinusSquareOutlined,
   PlusSquareOutlined,
   CheckOutlined,
@@ -34,7 +26,6 @@ import {
 } from "@ant-design/icons";
 
 import dateToString from "../../utils/dateToString";
-import weakMapMemoize from "../../utils/weak-map-memoize";
 import itemRender from "../../utils/breadcrumbItemRender";
 import AppPageHeader from "../AppPageHeader";
 import PageContent from "../PageContent";
@@ -45,7 +36,6 @@ import routes from "./routes";
 import canWrite from "./canWrite";
 
 const { Title, Text } = Typography;
-
 
 
 const getTrueByID =
@@ -140,9 +130,6 @@ function UserReport({user, groupsByID, expandedGroups, setExpandedGroups, onLoad
   const isFetchingRevisions = user.revisions?.isFetching;
   const groups = hasRevisions ? revisions.results : [];
 
-  const expandAll = () => setExpandedGroups(getTrueByID(groups));
-  const closeAll = () => setExpandedGroups({});
-
   return (
     <>
       {error &&
@@ -164,18 +151,6 @@ function UserReport({user, groupsByID, expandedGroups, setExpandedGroups, onLoad
         History
       </Title>
       <Space direction="vertical" style={{ width: '100%' }}>
-        <Row>
-          <Col sm={24}>
-            <Button.Group>
-              <Button type="secondary" size="small" onClick={expandAll} icon={<ArrowsAltOutlined />}>
-                Expand All
-              </Button>
-              <Button type="secondary" size="small" onClick={closeAll} icon={<ShrinkOutlined />}>
-                Close All
-              </Button>
-            </Button.Group>
-          </Col>
-        </Row>
         <div style={{ width: '100%' }}>
           <Card>
             <Timeline
@@ -263,7 +238,7 @@ function TimelineEntry({ revision, expandedGroups, setExpandedGroups, listVersio
         >
           <span style={expandIconStyle}>
             {isExpanded ? <MinusSquareOutlined /> : <PlusSquareOutlined />}
-          </span>{' '}{revision.comment}{`  #${revision.id}`}
+          </span>{' '}{revision.comment}
         </Button>
       </div>
       {isExpanded &&

--- a/frontend/src/components/users/UsersDetailContent.js
+++ b/frontend/src/components/users/UsersDetailContent.js
@@ -40,19 +40,20 @@ import AppPageHeader from "../AppPageHeader";
 import PageContent from "../PageContent";
 import ErrorMessage from "../ErrorMessage";
 import EditButton from "../EditButton";
-import {listVersions, get} from "../../modules/users/actions";
+import {listRevisions, listVersions, get} from "../../modules/users/actions";
 import routes from "./routes";
 import canWrite from "./canWrite";
 
 const { Title, Text } = Typography;
 
-const groupByRevisionID = weakMapMemoize(
-  compose(
-    map(sortBy(path(['content_type', 'id']))),
-    reverse,
-    values,
-    groupBy(path(['revision', 'id']))
-  ))
+// const groupByRevisionID = weakMapMemoize(
+//   compose(
+//     map(sortBy(path(['content_type', 'id']))),
+//     reverse,
+//     values,
+//     groupBy(path(['revision', 'id']))
+//   ))
+
 
 const getTrueByID =
   compose(
@@ -78,9 +79,9 @@ const mapStateToProps = state => ({
   groupsByID: state.groups.itemsByID,
 });
 
-const mapDispatchToProps = {get, listVersions};
+const mapDispatchToProps = {get, listRevisions, listVersions};
 
-const ReportsUserContent = ({canWrite, isFetching, usersError, usersByID, groupsByID, get, listVersions}) => {
+const ReportsUserContent = ({canWrite, isFetching, usersError, usersByID, groupsByID, get, listRevisions, listVersions}) => {
   const history = useHistory();
   const {id} = useParams();
   const [expandedGroups, setExpandedGroups] = useState({});
@@ -91,12 +92,17 @@ const ReportsUserContent = ({canWrite, isFetching, usersError, usersByID, groups
     get(id)
   }
 
-  if (user && !user.versions && !user.isFetching) {
-    setTimeout(() => listVersions(user.id), 0);
+  // if (user && !user.versions && !user.isFetching) {
+  //   setTimeout(() => listVersions(user.id), 0);
+  // }
+
+  if (user && !user.revisions && !user.isFetching) {
+    setTimeout(() => listRevisions(user.id), 0);
   }
 
   const onLoadMore = () => {
-    listVersions(user.id)
+    // listVersions(user.id)
+    listRevisions(user.id)
   }
 
   return (
@@ -140,10 +146,14 @@ function UserReport({user, groupsByID, expandedGroups, setExpandedGroups, onLoad
 
   const error = user.error;
   const isFetching = user.isFetching;
-  const versions = user.versions;
-  const hasVersions = versions?.results !== undefined
-  const isFetchingVersions = user.versions?.isFetching;
-  const groups = hasVersions ? groupByRevisionID(versions.results) : [];
+  // const versions = user.versions;
+  // const hasVersions = versions?.results !== undefined
+  // const isFetchingVersions = user.versions?.isFetching;
+  // const groups = hasVersions ? groupByRevisionID(versions.results) : [];
+  const revisions = user.revisions;
+  const hasRevisions = revisions?.results !== undefined
+  const isFetchingRevisions = user.revisions?.isFetching;
+  const groups = hasRevisions ? revisions.results : [];
 
   const expandAll = () => setExpandedGroups(getTrueByID(groups));
   const closeAll = () => setExpandedGroups({});
@@ -184,31 +194,31 @@ function UserReport({user, groupsByID, expandedGroups, setExpandedGroups, onLoad
         <div style={{ width: '100%' }}>
           <Card>
             <Timeline
-              pending={(isFetching && !versions) ? "Loading..." : undefined}
+              pending={(isFetching && !revisions) ? "Loading..." : undefined}
               mode="left"
               style={{ marginLeft: 0, width: '100%' }}
             >
-              {versions === undefined && isFetching &&
+              {revisions === undefined && isFetching &&
                 <Timeline.Item pending={true}>Loading...</Timeline.Item>
               }
-              {versions && groups.map((group, i) =>
+              {revisions && groups.map((revision, i) =>
                 <Timeline.Item
                   key={i}
-                  label={renderTimelineLabel(group[0].revision)}
+                  label={renderTimelineLabel(revision)}
                 >
                   <TimelineEntry
-                    group={group}
+                    revision={revision}
                     expandedGroups={expandedGroups}
                     setExpandedGroups={setExpandedGroups}
                   />
                 </Timeline.Item>
               )}
             </Timeline>
-            {((hasVersions && versions.next) || (!hasVersions && isFetchingVersions)) &&
+            {((hasRevisions && revisions.next) || (!hasRevisions && isFetchingRevisions)) &&
               <Button
                 block
                 type="link"
-                loading={isFetching || isFetchingVersions}
+                loading={isFetching || isFetchingRevisions}
                 onClick={onLoadMore}
               >
                 Load more
@@ -239,8 +249,7 @@ const tableStyle = {
   marginTop: '0.5em',
 }
 
-function TimelineEntry({ group, expandedGroups, setExpandedGroups }) {
-  const revision = group[0].revision
+function TimelineEntry({ revision, expandedGroups, setExpandedGroups }) {
   const isExpanded = expandedGroups[revision.id];
 
   // noinspection JSUnusedGlobalSymbols
@@ -258,21 +267,21 @@ function TimelineEntry({ group, expandedGroups, setExpandedGroups }) {
           </span>{' '}{revision.comment}
         </Button>
       </div>
-      {isExpanded &&
-        <Table
-          size="small"
-          style={tableStyle}
-          columns={columns}
-          expandable={{
-            expandedRowRender: version =>
-              <p style={{ margin: 0 }}>
-                {version.serialized_data}
-              </p>,
-            rowExpandable: () => true,
-          }}
-          dataSource={group}
-        />
-      }
+      {/*{isExpanded &&*/}
+      {/*  <Table*/}
+      {/*    size="small"*/}
+      {/*    style={tableStyle}*/}
+      {/*    columns={columns}*/}
+      {/*    expandable={{*/}
+      {/*      expandedRowRender: version =>*/}
+      {/*        <p style={{ margin: 0 }}>*/}
+      {/*          {version.serialized_data}*/}
+      {/*        </p>,*/}
+      {/*      rowExpandable: () => true,*/}
+      {/*    }}*/}
+      {/*    dataSource={group}*/}
+      {/*  />*/}
+      {/*}*/}
     </>
   )
 }

--- a/frontend/src/modules/samples/reducers.js
+++ b/frontend/src/modules/samples/reducers.js
@@ -1,7 +1,7 @@
 import {merge, set} from "object-path-immutable";
 import {map} from "rambda"
 
-import {preprocessSampleVersions} from "../../utils/preprocessVersions";
+import {preprocessSampleVersions} from "../../utils/preprocessRevisions";
 import {indexByID} from "../../utils/objects";
 import mergeArray from "../../utils/mergeArray";
 import {summaryReducerFactory} from "../../utils/summary";

--- a/frontend/src/modules/users/actions.js
+++ b/frontend/src/modules/users/actions.js
@@ -87,14 +87,14 @@ export const listRevisions = (id) => (dispatch, getState) => {
     );
 }
 
-export const listVersions = (id) => (dispatch, getState) => {
-    const user = getState().users.itemsByID[id];
+export const listVersions = (userId, revisionId) => (dispatch, getState) => {
+    const user = getState().users.itemsByID[userId];
     if (user.isFetching) return Promise.resolve();
-    const meta = { id };
+    const meta = { id: userId };
     return dispatch(
         networkAction(
             LIST_VERSIONS,
-            api.users.listVersions(id, user?.versions?.next ?? { limit: 10000 }),
+            api.users.listVersions(userId, {revision__id: revisionId, limit: 10000}),
             { meta }
         )
     );

--- a/frontend/src/modules/users/actions.js
+++ b/frontend/src/modules/users/actions.js
@@ -10,6 +10,7 @@ export const ADD = createNetworkActionTypes("USERS.ADD");
 export const UPDATE = createNetworkActionTypes("USERS.UPDATE");
 export const LIST = createNetworkActionTypes("USERS.LIST");
 export const LIST_TABLE = createNetworkActionTypes("USERS.LIST_TABLE");
+export const LIST_REVISIONS = createNetworkActionTypes("USERS.LIST_REVISIONS");
 export const LIST_VERSIONS = createNetworkActionTypes("USERS.LIST_VERSIONS");
 export const SET_SORT_BY = "USERS.SET_SORT_BY";
 export const SET_FILTER = "USERS.SET_FILTER";
@@ -73,6 +74,19 @@ export const listTable = ({ offset = 0, limit = DEFAULT_PAGINATION_LIMIT } = {},
     return res
 };
 
+export const listRevisions = (id) => (dispatch, getState) => {
+    const user = getState().users.itemsByID[id];
+    if (user.isFetching) return Promise.resolve();
+    const meta = { id };
+    return dispatch(
+        networkAction(
+            LIST_REVISIONS,
+            api.users.listRevisions(id, user?.revisions?.next ?? { limit: 100 }),
+            { meta }
+        )
+    );
+}
+
 export const listVersions = (id) => (dispatch, getState) => {
     const user = getState().users.itemsByID[id];
     if (user.isFetching) return Promise.resolve();
@@ -85,7 +99,6 @@ export const listVersions = (id) => (dispatch, getState) => {
         )
     );
 }
-
 
 export const setSortBy = thenList((key, order) => {
     return {
@@ -120,6 +133,7 @@ export default {
     UPDATE,
     LIST,
     LIST_TABLE,
+    LIST_REVISIONS,
     LIST_VERSIONS,
     SET_SORT_BY,
     SET_FILTER,
@@ -130,6 +144,7 @@ export default {
     update,
     list,
     listTable,
+    listRevisions,
     listVersions,
     setSortBy,
     setFilter,

--- a/frontend/src/modules/users/reducers.js
+++ b/frontend/src/modules/users/reducers.js
@@ -3,7 +3,7 @@ import {indexByID} from "../../utils/objects";
 import mergeArray from "../../utils/mergeArray";
 
 import shouldIgnoreError from "../../utils/shouldIgnoreError";
-import {preprocessUserActionVersions} from "../../utils/preprocessVersions";
+import {preprocessUserActionVersions, preprocessUserActionRevisions} from "../../utils/preprocessRevisions";
 import {resetTable} from "../../utils/reducers";
 import USERS from "./actions";
 
@@ -104,6 +104,21 @@ export const users = (
     }
     case USERS.LIST_TABLE.ERROR:
       return { ...state, isFetching: false, error: shouldIgnoreError(action) ? undefined : action.error };
+
+    case USERS.LIST_REVISIONS.REQUEST:
+      return set(state, ['itemsByID', action.meta.id, 'revisions', 'isFetching'], true);
+    case USERS.LIST_REVISIONS.RECEIVE:
+      return merge(state, ['itemsByID', action.meta.id], {
+        revisions: preprocessUserActionRevisions(
+          state.itemsByID[action.meta.id].revisions,
+          action.data
+        ),
+      });
+    case USERS.LIST_REVISIONS.ERROR:
+      return merge(state, ['itemsByID', action.meta.id], {
+        revisions: { isFetching: false },
+        error: action.error,
+      });
 
     case USERS.LIST_VERSIONS.REQUEST:
       return set(state, ['itemsByID', action.meta.id, 'versions', 'isFetching'], true);

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -86,6 +86,7 @@ const api = {
     update: user => patch(`/users/${user.id}/`, user),
     updateSelf: user => patch(`/users/update_self/`, user),
     list: (options, abort) => get("/users", options, { abort }),
+    listRevisions: (userId, options = {}) => get(`/revisions`, { user_id: userId, ...options }),
     listVersions: (userId, options = {}) => get(`/versions`, { revision__user: userId, ...options }),
   },
 

--- a/frontend/src/utils/preprocessRevisions.js
+++ b/frontend/src/utils/preprocessRevisions.js
@@ -1,5 +1,18 @@
 import {parse} from "querystring";
 
+export function preprocessUserActionRevisions(previousRevisions, /* mut */ revisions) {
+  let options = null
+  if (revisions.next)
+    options = parse(revisions.next.replace(/^.*\?/, ''))
+
+  return {
+    isFetching: false,
+    count: revisions.count,
+    next: options,
+    results: (previousRevisions?.results ?? []).concat(revisions.results),
+  }
+}
+
 export function preprocessUserActionVersions(previousVersions, /* mut */ versions) {
   versions.results.forEach(version => {
     version.key = version.id;


### PR DESCRIPTION
More efficient way of loading versions in a User details page. 
On page loading, it loads the Revision objects. And it only loads the corresponding Version objects when you click on a Revision (+) button. 

@romgrk not a big deal, but I'm not sure about having those Versions still stored in the Redux store (under Users/itemsByID/Versions).. 
