### PR TITLE
Set empty warning when too many errors.

### DIFF
--- a/backend/fms_core/resources/_generic.py
+++ b/backend/fms_core/resources/_generic.py
@@ -70,6 +70,7 @@ class GenericResource(resources.ModelResource):
         else:
             row_result = self.get_row_result_class()()
             row_result.import_type = RowResult.IMPORT_TYPE_SKIP
+            row_result.warnings = []
         return row_result
 
     def after_import(self, dataset, result, using_transactions, dry_run, **kwargs):


### PR DESCRIPTION
The template fails when there is too many errors because the warnings are not set. Setting the warning to an empty list in that case.