### PR TITLE
Recursive container search

### DIFF
--- a/backend/fms_core/viewsets.py
+++ b/backend/fms_core/viewsets.py
@@ -566,6 +566,8 @@ class SampleViewSet(viewsets.ModelViewSet, TemplateActionsMixin):
 
             container_ids = tuple(containers.values_list('id', flat=True))
 
+            if not container_ids:
+                container_ids = tuple([None])
 
             parent_containers = Container.objects.raw('''WITH RECURSIVE parent(id, location_id) AS (
                                                                SELECT id, location_id

--- a/frontend/src/components/PaginatedTable.js
+++ b/frontend/src/components/PaginatedTable.js
@@ -87,7 +87,7 @@ function PaginatedTable ({
         columns={columns}
         dataSource={hasUnloadedItems ? [] : dataSource}
         rowKey={rowKey}
-        loading={loading && isCurrentPageUnloaded}
+        loading={loading || isCurrentPageUnloaded}
         childrenColumnName={'UNEXISTENT_KEY'}
         onChange={onChangeTable}
       />

--- a/frontend/src/components/filters/descriptions.js
+++ b/frontend/src/components/filters/descriptions.js
@@ -22,11 +22,13 @@ export const SAMPLE_FILTERS = {
     type: FILTER_TYPE.INPUT,
     key: "container__name",
     label: "Container Name",
+    recursive: true,
   },
   container__barcode: {
     type: FILTER_TYPE.INPUT,
     key: "container__barcode",
     label: "Container Barcode",
+    recursive: true,
   },
   coordinates: {
     type: FILTER_TYPE.INPUT,

--- a/frontend/src/components/filters/getFilterProps.js
+++ b/frontend/src/components/filters/getFilterProps.js
@@ -48,12 +48,12 @@ function getInputFilterProps(column, descriptions, filters, setFilter, setFilter
       confirm()
   }
 
-  const onToggleSwitch = (checked, option )=> {
-    setFilterOption(dataIndex, option, checked)
+  const onToggleSwitch = (key, checked )=> {
+    setFilterOption(dataIndex, key, checked)
   }
 
   const onChangeRecursive = checked => {
-    onToggleSwitch(checked, 'recursiveMatch')
+    onToggleSwitch( 'recursiveMatch', checked)
     setFilterOption(dataIndex, 'exactMatch', checked)
   }
 
@@ -65,7 +65,7 @@ function getInputFilterProps(column, descriptions, filters, setFilter, setFilter
             ref={inputRef}
             allowClear
             placeholder={`Search ${description.label}`}
-            style={{ marginRight: 8}}
+            style={{ marginRight: 8 }}
             value={value}
             onChange={e => onSearch(e.target.value)}
             onPressEnter={confirm}
@@ -79,7 +79,7 @@ function getInputFilterProps(column, descriptions, filters, setFilter, setFilter
                 unCheckedChildren="Exact"
                 checked={options?.exactMatch ?? false}
                 disabled={options?.recursiveMatch ?? false}
-                onChange={e => onToggleSwitch(e, 'exactMatch')}
+                onChange={e => onToggleSwitch( 'exactMatch', e)}
               />
             </Tooltip>
             {description.recursive &&

--- a/frontend/src/components/filters/getFilterProps.js
+++ b/frontend/src/components/filters/getFilterProps.js
@@ -48,31 +48,52 @@ function getInputFilterProps(column, descriptions, filters, setFilter, setFilter
       confirm()
   }
 
-  const onToggleSwitch = checked => {
+  const onToggleSwitch = (checked, option )=> {
+    setFilterOption(dataIndex, option, checked)
+  }
+
+  const onChangeRecursive = checked => {
+    onToggleSwitch(checked, 'recursiveMatch')
     setFilterOption(dataIndex, 'exactMatch', checked)
   }
 
   return {
     filterIcon: getFilterIcon(Boolean(value)),
     filterDropdown: ({ confirm }) => (
-      <div style={{ padding: 8, display: 'flex', alignItems: 'center' }}>
-        <Input
-          ref={inputRef}
-          allowClear
-          placeholder={`Search ${description.label}`}
-          style={{ marginRight: 8 }}
-          value={value}
-          onChange={e => onSearch(e.target.value)}
-          onPressEnter={confirm}
-          onKeyDown={ev => onKeyDown(ev, confirm)}
-        />
-        <Tooltip title="Exact Match">
-          <Switch
-            size='small'
-            checked={options?.exactMatch ?? false}
-            onChange={e => onToggleSwitch(e, dataIndex)}
+      <div style={{ padding: 8, alignItems: 'center' }}>
+          <Input
+            ref={inputRef}
+            allowClear
+            placeholder={`Search ${description.label}`}
+            style={{ marginRight: 8}}
+            value={value}
+            onChange={e => onSearch(e.target.value)}
+            onPressEnter={confirm}
+            onKeyDown={ev => onKeyDown(ev, confirm)}
           />
-        </Tooltip>
+          <div style={{ padding: 8, alignItems: 'right' }}>
+            <Tooltip title="Exact Match">
+              <Switch
+                size="large"
+                checkedChildren="Exact"
+                unCheckedChildren="Exact"
+                checked={options?.exactMatch ?? false}
+                disabled={options?.recursiveMatch ?? false}
+                onChange={e => onToggleSwitch(e, 'exactMatch')}
+              />
+            </Tooltip>
+            {description.recursive &&
+              <Tooltip title="Exhaustive">
+                <Switch
+                  checkedChildren="Recursive"
+                  unCheckedChildren="Recursive"
+                  checked={options?.recursiveMatch ?? false}
+                  onChange={onChangeRecursive}
+                />
+              </Tooltip>
+            }
+          </div>
+
       </div>
     ),
     onFilterDropdownVisibleChange: visible => {

--- a/frontend/src/utils/serializeFilterParams.js
+++ b/frontend/src/utils/serializeFilterParams.js
@@ -38,7 +38,17 @@ export default function serializeFilterParams(filters, descriptions) {
 
       case FILTER_TYPE.INPUT: {
         const options = filters[field].options
-        key = (options && options.exactMatch) ? (key + "__startswith") : (key + "__icontains")
+
+        if (options) {
+          if (options.recursiveMatch)
+            key += "__recursive"
+          else if (options.exactMatch)
+            key += "__startswith"
+          else
+            key += "__icontains"
+        } else {
+          key += "__icontains"
+        }
 
         if(value)
           params[key] = value


### PR DESCRIPTION
Description: This allows the user to lookup samples by containers recursively. Let's say rack 1 (barcode: rack1) contains tube A (sample A), tube B (sample B), tube C (sample C). When looking up in the Sample list page by applying filter container barcode 'rack1', you will get a list of samples with sample A, sample B, sample C. Previously you would not get any sample in the list, because rack1 does not contain any sample directly.

Name of recursive option and variable are open for discussion :) 