### PR TITLE
Fix TemplateFlow with errors but no base error

### DIFF
--- a/frontend/src/components/TemplateFlow.js
+++ b/frontend/src/components/TemplateFlow.js
@@ -102,7 +102,7 @@ function renderResultOK(checkResult) {
 const wasInterrupted = checkResult => {
     return (
         <>
-          { checkResult?.base_errors.length > 0 && checkResult.base_errors.map(baseError =>
+          { checkResult?.base_errors?.length > 0 && checkResult.base_errors.map(baseError =>
               <p>
                 {baseError.error}
               </p>)


### PR DESCRIPTION
In the case where there are errors found while submitting the template, but those are errors independent from the template submission, the page would crash and not render.

This fix would at least not make the page crash and display an error such as 
![image](https://user-images.githubusercontent.com/1617741/128201357-b6e7f4ad-b0fd-46fc-8941-3e655a339524.png)
