### PR TITLE
add instruction on how to route git for github

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@
 ## Installation
 
 ```bash
+# Route git: protocol to allow recursive clone
+git config --global url."https://github.com/".insteadOf 'git://github.com/'
+# git config --global url."git@github.com:".insteadOf 'git://github.com/'
+
 # Clone the repository
 git clone https://github.com/c3g/freezeman
 cd freezeman


### PR DESCRIPTION
Cloning [romgrk](https://github.com/romgrk)'s repo was really painful, and it was apparently because the .submodule files use the git: protocol, so I added  an instruction on how to route git protocol to https or ssh for GitHub repos.