### PR TITLE
Fix molecular_weight_approx for single stranded dna

### DIFF
--- a/backend/fms_core/models/library.py
+++ b/backend/fms_core/models/library.py
@@ -31,7 +31,7 @@ class Library(TrackedModel):
 
     @property
     def molecular_weight_approx(self):
-        return Decimal(SSDNA_MW if self.strandedness is SINGLE_STRANDED else DSDNA_MW)
+        return Decimal(SSDNA_MW if self.strandedness == SINGLE_STRANDED else DSDNA_MW)
     
     def clean(self):
         super().clean()


### PR DESCRIPTION
Hotfix for QC branch

Changed:

`return Decimal(SSDNA_MW if self.strandedness is SINGLE_STRANDED else DSDNA_MW)`

to:

`return Decimal(SSDNA_MW if self.strandedness == SINGLE_STRANDED else DSDNA_MW)`

The `is` comparison fails if self.strandedness is not the string constant object SSDNA_MW - if it's a copy of the string then the test fails and the function always returns DSDNA_MW, leading to an error when we calculate the concentration in nM.