### PR TITLE
Fix container type casing error for "Tube" type

### DIFF
--- a/backend/fms_core/template_importer/importers/sample_submission.py
+++ b/backend/fms_core/template_importer/importers/sample_submission.py
@@ -3,7 +3,7 @@ from ._generic import GenericImporter
 from fms_core.template_importer.row_handlers.sample_submission import SampleRowHandler
 from fms_core.templates import SAMPLE_SUBMISSION_TEMPLATE
 from .._utils import float_to_decimal_and_none, input_to_date_and_none, input_to_integer_and_none
-from fms_core.utils import str_cast_and_normalize
+from fms_core.utils import str_cast_and_normalize, str_cast_and_normalize_lower
 
 class SampleSubmissionImporter(GenericImporter):
     SHEETS_INFO = SAMPLE_SUBMISSION_TEMPLATE["sheets info"]
@@ -20,7 +20,7 @@ class SampleSubmissionImporter(GenericImporter):
 
         for row_id, row_data in enumerate(samples_sheet.rows):
             container = {
-                'kind': str_cast_and_normalize(row_data['Container Kind']),
+                'kind': str_cast_and_normalize_lower(row_data['Container Kind']),   # container kinds must be lower case to match model
                 'name': str_cast_and_normalize(row_data['Container Name']),
                 'barcode': str_cast_and_normalize(row_data['Container Barcode']),
                 'coordinates': str_cast_and_normalize(row_data['Container Coord']),

--- a/backend/fms_core/utils.py
+++ b/backend/fms_core/utils.py
@@ -81,7 +81,7 @@ def str_cast_and_normalize(s) -> str:
 
 def str_cast_and_normalize_lower(s) -> Union[str, None]:
     """
-    Cases a value to a string, normalizes it and then converts to lower case.
+    Casts a value to a string, normalizes it and then converts to lower case.
     """
     result = str_cast_and_normalize(s)
     return result.lower() if result is not None else result

--- a/backend/fms_core/utils.py
+++ b/backend/fms_core/utils.py
@@ -79,6 +79,14 @@ def str_cast_and_normalize(s) -> str:
     return str_normalize(str(s) if s is not None else s)
 
 
+def str_cast_and_normalize_lower(s) -> Union[str, None]:
+    """
+    Cases a value to a string, normalizes it and then converts to lower case.
+    """
+    result = str_cast_and_normalize(s)
+    return result.lower() if result is not None else result
+
+
 def get_normalized_str(d: dict, key: str, default: str = "") -> str:
     """
     Gets a string-valued item from a dictionary using a provided key. If the


### PR DESCRIPTION
Fixes redmine issue: [Feature #1185](https://206.12.92.46/issues/1185)

Container kind strings are stored in lower case in the db. In the sample submission form the drop down uses "Tube" as the type. Container kind strings need to be converted to lowercase by the importer.