### PR TITLE
Fix sample name warning

### DIFF
--- a/backend/fms_core/template_importer/row_handlers/sample_submission/sample.py
+++ b/backend/fms_core/template_importer/row_handlers/sample_submission/sample.py
@@ -135,10 +135,10 @@ class SampleRowHandler(GenericRowHandler):
             # Output different warnings depending on whether the name is an exact match or a case insensitive match
             if Sample.objects.filter(name__exact=sample['name']).exists():
                 self.warnings['name'] = f'Sample with the same name [{sample["name"]}] already exists.' \
-                                    f'A new sample with the same name will be created'
+                                        f'A new sample with the same name will be created'
             else:
                 self.warnings['name'] = f'Sample with the same name [{sample["name"]}] but different type casing already exists.' \
-                                    f'Please verify the name is correct.'
+                                        f'Please verify the name is correct.'
 
             
         sample_obj = None

--- a/backend/fms_core/template_importer/row_handlers/sample_submission/sample.py
+++ b/backend/fms_core/template_importer/row_handlers/sample_submission/sample.py
@@ -137,7 +137,7 @@ class SampleRowHandler(GenericRowHandler):
                 self.warnings['name'] = f'Sample with the same name [{sample["name"]}] already exists. ' \
                                         f'A new sample with the same name will be created.'
             else:
-                self.warnings['name'] = f'Sample with the same name [{sample["name"]}] but different type casing already exists.' \
+                self.warnings['name'] = f'Sample with the same name [{sample["name"]}] but different type casing already exists. ' \
                                         f'Please verify the name is correct.'
 
             

--- a/backend/fms_core/template_importer/row_handlers/sample_submission/sample.py
+++ b/backend/fms_core/template_importer/row_handlers/sample_submission/sample.py
@@ -131,15 +131,16 @@ class SampleRowHandler(GenericRowHandler):
                                                                                            strandedness=library['strandedness'])
 
         # Check if there's a sample with the same name
-        if Sample.objects.filter(name=sample['name']).exists():
-            self.warnings['name'] = f'Sample with the same name [{sample["name"]}] already exists.' \
-                                    f'A new sample with the same name will be created'
-
-        # Check if there's a sample with the same name in different case
         if Sample.objects.filter(name__iexact=sample['name']).exists():
-            self.warnings['name'] = f'Sample with the same name [{sample["name"]}] but different case already exists.' \
+            # Output different warnings depending on whether the name is an exact match or a case insensitive match
+            if Sample.objects.filter(name__exact=sample['name']).exists():
+                self.warnings['name'] = f'Sample with the same name [{sample["name"]}] already exists.' \
+                                    f'A new sample with the same name will be created'
+            else:
+                self.warnings['name'] = f'Sample with the same name [{sample["name"]}] but different type casing already exists.' \
                                     f'Please verify the name is correct.'
 
+            
         sample_obj = None
         if library_obj is not None or not is_library:
             sample_obj, self.errors['sample'], self.warnings['sample'] = \

--- a/backend/fms_core/template_importer/row_handlers/sample_submission/sample.py
+++ b/backend/fms_core/template_importer/row_handlers/sample_submission/sample.py
@@ -134,8 +134,8 @@ class SampleRowHandler(GenericRowHandler):
         if Sample.objects.filter(name__iexact=sample['name']).exists():
             # Output different warnings depending on whether the name is an exact match or a case insensitive match
             if Sample.objects.filter(name__exact=sample['name']).exists():
-                self.warnings['name'] = f'Sample with the same name [{sample["name"]}] already exists.' \
-                                        f'A new sample with the same name will be created'
+                self.warnings['name'] = f'Sample with the same name [{sample["name"]}] already exists. ' \
+                                        f'A new sample with the same name will be created.'
             else:
                 self.warnings['name'] = f'Sample with the same name [{sample["name"]}] but different type casing already exists.' \
                                         f'Please verify the name is correct.'


### PR DESCRIPTION
If an imported sample name has an case-insensitive match with an existing sample then check to see if it's an exact match and output the appropriate warning.