### PR TITLE
Configure redux logger

### DIFF
--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -1,10 +1,21 @@
 import {applyMiddleware, createStore, compose} from "redux";
 import thunkMiddleware from "redux-thunk";
-import logger from "redux-logger";
+import {createLogger} from "redux-logger";
 
 import rootReducer from "./reducers";
 
 export default function configureStore(initialState) {
+
+  // Log redux actions as 'info' so that they can be filtered out of the console
+  // output when we are not interested in the actions. The default is to log them
+  // at the 'log' level which fills the console with noise that cannot be filtered.
+  // Here, we are using the createLogger function to create the logger with options,
+  // instead of importing the default redux logger.
+  // To view redux logging, enable 'info' level messages in the browser's console.
+  const logger = createLogger({
+    level: 'info'
+  })
+
   const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
   const store = createStore(
     rootReducer,


### PR DESCRIPTION
Configure the redux logger to log actions as 'info' messages so that we can show or hide them in the browser console. By default, the redux logger logs them as 'log' messages which cannot be filtered in the console, so the console is flooded with noise, making it tiresome to check for errors and warnings. With this change, we can hide the redux action logging by disabling 'info' messages in the console.