### PR TITLE
Fix corrupt imported template downloads RM#1199

### DIFF
--- a/backend/fms_core/viewsets/imported_file.py
+++ b/backend/fms_core/viewsets/imported_file.py
@@ -45,7 +45,7 @@ class ImportedFileViewSet(viewsets.ModelViewSet):
         try:
             with open(file_path, "rb") as file:
                 response = HttpResponse(content=file)
-                response["Content-Type"] = mime_type_guess[0]
+                response["Content-Type"] = mime_type_guess[0] if mime_type_guess[0] != None else 'application/octet-stream'
                 response["Content-Disposition"] = "attachment; filename=" + filename
         except Exception as err:
             print(err)

--- a/backend/fms_core/viewsets/imported_file.py
+++ b/backend/fms_core/viewsets/imported_file.py
@@ -1,6 +1,5 @@
 import os
 import json
-import mimetypes
 
 from rest_framework import viewsets
 from rest_framework.decorators import action
@@ -26,11 +25,6 @@ class ImportedFileViewSet(viewsets.ModelViewSet):
         **_imported_file_filterset_fields,
     }
 
-    def __init__(self, **kwargs) -> None:
-        super().__init__(**kwargs)
-        # Make sure that mimetypes is initialized so that a mapping for .xlsx files exists.
-        mimetypes.init()
-
     @action(detail=True, methods=["get"])
     def download(self, _request, pk) -> Response:
         """
@@ -45,12 +39,15 @@ class ImportedFileViewSet(viewsets.ModelViewSet):
         queryset = self.get_queryset().filter(id=pk)
         filename = queryset.first().filename
         file_path = os.path.join(settings.TEMPLATE_UPLOAD_PATH, filename)
-        mime_type_guess = mimetypes.guess_type(file_path)
         
         try:
             with open(file_path, "rb") as file:
                 response = HttpResponse(content=file)
-                response["Content-Type"] = mime_type_guess[0] if mime_type_guess[0] != None else 'application/octet-stream'
+                response["Content-Encoding"] = 'identity'
+                # NOTE: Currently, the frontend mangles template files by converting them to unicode text
+                # if the Content-Type is not set to the following value. 
+                # TODO: Remove this note once the frontend has been fixed.
+                response["Content-Type"] = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
                 response["Content-Disposition"] = "attachment; filename=" + filename
         except Exception as err:
             print(err)

--- a/backend/fms_core/viewsets/imported_file.py
+++ b/backend/fms_core/viewsets/imported_file.py
@@ -26,6 +26,11 @@ class ImportedFileViewSet(viewsets.ModelViewSet):
         **_imported_file_filterset_fields,
     }
 
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        # Make sure that mimetypes is initialized so that a mapping for .xlsx files exists.
+        mimetypes.init()
+
     @action(detail=True, methods=["get"])
     def download(self, _request, pk) -> Response:
         """

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -334,6 +334,18 @@ function attachData(response) {
   if (filename)
     response.filename = filename
 
+  /*
+    TODO: This code was causing downloaded excel templates to become corrupted because
+    the backend was sending "None" as a Content-Type, due to a problem with mime types.
+    We tried to fix that by hard-coding the content-type as 'application/octet-stream' but
+    the files were still corrupt.
+
+    The problem was traced to this code. By default, the response is converted to text unless
+    the content-type correctly identifies the file as an excel sheet.
+
+    This was a difficult problem to figure out. This code needs to be improved to avoid
+    the same problem in the future if we transer other binary data types.
+  */
   const isJSON = contentType.includes('/json')
   response.isJSON = isJSON
   const isExcel = contentType.includes('/ms-excel') || contentType.includes('/vnd.openxmlformats-officedocument.spreadsheetml.sheet')


### PR DESCRIPTION
Fixes redmine ticket https://206.12.92.46/issues/1199

The original problem seems to be caused by the Content-Type being set to None for the downloaded file.

We are using the `mimetypes` python module to determine a content type for the template file. By default, mimetypes gets the mime types from the system on which it is running. On our dev machines, it is getting it from MacOS or Linux. I guess that on the server there is no mapping for xlsx files, and the `mimetypes.guess_types()` call is returning None.

My simple fix is to default to `application/octet-stream` if guess_types returns None.

I am also going to see how complicated it is to configure the mimetype for xlsx files, to return the proper type without defaulting to system types. `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`


