### PR TITLE
Quick fix for infinite loop of item requests

### DIFF
--- a/backend/fms_core/viewsets/_constants.py
+++ b/backend/fms_core/viewsets/_constants.py
@@ -42,6 +42,7 @@ _individual_filterset_fields: FiltersetFields = {
 }
 
 _user_filterset_fields: FiltersetFields = {
+    "id": PK_FILTERS,
     "username": FREE_TEXT_FILTERS,
     "email": FREE_TEXT_FILTERS,
 }

--- a/frontend/src/components/filters/descriptions.js
+++ b/frontend/src/components/filters/descriptions.js
@@ -2,7 +2,7 @@ import {FILTER_TYPE, SEX, TAXON, PROJECT_STATUS, QPCR_SELECTION_STATUS} from "..
 
 export const SAMPLE_FILTERS = {
   id: {
-    type: FILTER_TYPE.INPUT_NUMBER,
+    type: FILTER_TYPE.INPUT_OBJECT_ID,
     key: "id",
     label: "Sample ID",
   },
@@ -140,7 +140,7 @@ export const SAMPLE_FILTERS = {
 
 export const CONTAINER_FILTERS = {
   id: {
-    type: FILTER_TYPE.INPUT_NUMBER,
+    type: FILTER_TYPE.INPUT_OBJECT_ID,
     key: "id",
     label: "id",
   },
@@ -183,7 +183,7 @@ export const CONTAINER_FILTERS = {
 
 export const INDIVIDUAL_FILTERS = {
   id: {
-    type: FILTER_TYPE.INPUT_NUMBER,
+    type: FILTER_TYPE.INPUT_OBJECT_ID,
     key: "id",
     label: "ID",
   },
@@ -222,12 +222,12 @@ export const INDIVIDUAL_FILTERS = {
 
 export const PROCESS_MEASUREMENT_FILTERS = {
   id: {
-    type: FILTER_TYPE.INPUT_NUMBER,
+    type: FILTER_TYPE.INPUT_OBJECT_ID,
     key: "id",
     label: "ID",
   },
   process: {
-    type: FILTER_TYPE.INPUT_NUMBER,
+    type: FILTER_TYPE.INPUT_OBJECT_ID,
     key: "process",
     label: "Process ID",
   },
@@ -264,7 +264,7 @@ export const PROCESS_MEASUREMENT_FILTERS = {
 
 export const EXPERIMENT_RUN_FILTERS = {
   id: {
-    type: FILTER_TYPE.INPUT_NUMBER,
+    type: FILTER_TYPE.INPUT_OBJECT_ID,
     key: "id",
     label: "ID",
   },
@@ -314,7 +314,7 @@ export const EXPERIMENT_RUN_FILTERS = {
 
 export const USER_FILTERS = {
   id: {
-    type: FILTER_TYPE.INPUT_NUMBER,
+    type: FILTER_TYPE.INPUT_OBJECT_ID,
     key: "id",
     label: "User ID"
   },
@@ -332,7 +332,7 @@ export const USER_FILTERS = {
 
 export const PROJECT_FILTERS = {
   id: {
-    type: FILTER_TYPE.INPUT_NUMBER,
+    type: FILTER_TYPE.INPUT_OBJECT_ID,
     key: "id",
     label: "Project ID"
   },
@@ -379,7 +379,7 @@ export const PROJECT_FILTERS = {
 
 export const INDEX_FILTERS = {
   id: {
-    type: FILTER_TYPE.INPUT_NUMBER,
+    type: FILTER_TYPE.INPUT_OBJECT_ID,
     key: "id",
     label: "ID",
   },
@@ -414,7 +414,7 @@ export const INDEX_FILTERS = {
 
 export const LIBRARY_FILTERS = {
   id: {
-    type: FILTER_TYPE.INPUT_NUMBER,
+    type: FILTER_TYPE.INPUT_OBJECT_ID,
     key: "id",
     label: "Library ID",
   },

--- a/frontend/src/components/filters/descriptions.js
+++ b/frontend/src/components/filters/descriptions.js
@@ -331,6 +331,11 @@ export const USER_FILTERS = {
 }
 
 export const PROJECT_FILTERS = {
+  id: {
+    type: FILTER_TYPE.INPUT_NUMBER,
+    key: "id",
+    label: "Project ID"
+  },
   name: {
     type: FILTER_TYPE.INPUT,
     key: "name",

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -7,7 +7,8 @@ export const FILTER_TYPE = {
   DATE_RANGE: "DATE_RANGE",
   SELECT: "SELECT",
   INPUT: "INPUT",
-  INPUT_NUMBER: "INPUT_NUMBER"
+  INPUT_NUMBER: "INPUT_NUMBER",
+  INPUT_OBJECT_ID: "INPUT_OBJECT_ID"  // A freezeman object ID - a positive integer value
 }
 
 export const SEX = [

--- a/frontend/src/modules/containers/reducers.js
+++ b/frontend/src/modules/containers/reducers.js
@@ -91,6 +91,7 @@ export const containers = (
         ...state,
         filters: set(state.filters, [action.data.name, 'value'], action.data.value),
         items: [],
+        totalCount: 0,
         page: set(state.page, ['offset'], 0),
       };
     case CONTAINERS.SET_FILTER_OPTION:
@@ -102,6 +103,7 @@ export const containers = (
           action.data.value
         ),
         items: [],
+        totalCount: 0,
         page: set(state.page, ['offset'], 0),
       };
     case CONTAINERS.CLEAR_FILTERS:
@@ -109,6 +111,7 @@ export const containers = (
         ...state,
         filters: {},
         items: [],
+        totalCount: 0,
         page: set(state.page, ['offset'], 0),
       };
 

--- a/frontend/src/modules/experimentRuns/reducers.js
+++ b/frontend/src/modules/experimentRuns/reducers.js
@@ -167,6 +167,7 @@ export const experimentRuns = (
                 ...state,
                 filters: set(state.filters, [action.data.name, 'value'], action.data.value),
                 items: [],
+                totalCount: 0,
                 page: set(state.page, ['offset'], 0),
             };
         case EXPERIMENT_RUNS.SET_FILTER_OPTION:
@@ -178,6 +179,7 @@ export const experimentRuns = (
                     action.data.value
                 ),
                 items: [],
+                totalCount: 0,
                 page: set(state.page, ['offset'], 0),
             };
         case EXPERIMENT_RUNS.CLEAR_FILTERS:
@@ -185,6 +187,7 @@ export const experimentRuns = (
                 ...state,
                 filters: {},
                 items: [],
+                totalCount: 0,
                 page: set(state.page, ['offset'], 0),
             };
 

--- a/frontend/src/modules/indices/reducers.js
+++ b/frontend/src/modules/indices/reducers.js
@@ -43,6 +43,7 @@ export const indices = (
                 ...state,
                 filters: set(state.filters, [action.data.name, 'value'], action.data.value),
                 items: [],
+                totalCount: 0,
                 page: set(state.page, ['offset'], 0),
             };
         case INDICES.SET_FILTER_OPTION:
@@ -54,6 +55,7 @@ export const indices = (
                     action.data.value
                 ),
                 items: [],
+                totalCount: 0,
                 page: set(state.page, ['offset'], 0),
             };
         case INDICES.CLEAR_FILTERS:
@@ -61,6 +63,7 @@ export const indices = (
                 ...state,
                 filters: {},
                 items: [],
+                totalCount: 0,
                 page: set(state.page, ['offset'], 0),
             };
 

--- a/frontend/src/modules/individuals/reducers.js
+++ b/frontend/src/modules/individuals/reducers.js
@@ -82,6 +82,7 @@ export const individuals = (
                 ...state,
                 filters: set(state.filters, [action.data.name, 'value'], action.data.value),
                 items: [],
+                totalCount: 0,
                 page: set(state.page, ['offset'], 0),
             };
         case INDIVIDUALS.SET_FILTER_OPTION:
@@ -93,6 +94,7 @@ export const individuals = (
                     action.data.value
                 ),
                 items: [],
+                totalCount: 0,
                 page: set(state.page, ['offset'], 0),
             };
         case INDIVIDUALS.CLEAR_FILTERS:
@@ -100,6 +102,7 @@ export const individuals = (
                 ...state,
                 filters: {},
                 items: [],
+                totalCount: 0,
                 page: set(state.page, ['offset'], 0),
             };
 

--- a/frontend/src/modules/libraries/reducers.js
+++ b/frontend/src/modules/libraries/reducers.js
@@ -45,6 +45,7 @@ export const libraries = (
                 ...state,
                 filters: set(state.filters, [action.data.name, 'value'], action.data.value),
                 items: [],
+                totalCount: 0,
                 page: set(state.page, ['offset'], 0),
             };
         case LIBRARIES.SET_FILTER_OPTION:
@@ -56,6 +57,7 @@ export const libraries = (
                     action.data.value
                 ),
                 items: [],
+                totalCount: 0,
                 page: set(state.page, ['offset'], 0),
             };
         case LIBRARIES.CLEAR_FILTERS:
@@ -63,6 +65,7 @@ export const libraries = (
                 ...state,
                 filters: {},
                 items: [],
+                totalCount: 0,
                 page: set(state.page, ['offset'], 0),
             };
 

--- a/frontend/src/modules/processMeasurements/reducers.js
+++ b/frontend/src/modules/processMeasurements/reducers.js
@@ -42,6 +42,7 @@ export const processMeasurements = (
                 ...state,
                 filters: set(state.filters, [action.data.name, 'value'], action.data.value),
                 items: [],
+                totalCount: 0,
                 page: set(state.page, ['offset'], 0),
             };
         case PROCESS_MEASUREMENTS.SET_FILTER_OPTION:
@@ -53,6 +54,7 @@ export const processMeasurements = (
                     action.data.value
                 ),
                 items: [],
+                totalCount: 0,
                 page: set(state.page, ['offset'], 0),
             };
         case PROCESS_MEASUREMENTS.CLEAR_FILTERS:
@@ -60,6 +62,7 @@ export const processMeasurements = (
                 ...state,
                 filters: {},
                 items: [],
+                totalCount: 0,
                 page: set(state.page, ['offset'], 0),
             };
 

--- a/frontend/src/modules/projects/reducers.js
+++ b/frontend/src/modules/projects/reducers.js
@@ -59,6 +59,7 @@ export const projects = (
                 ...state,
                 filters: set(state.filters, [action.data.name, 'value'], action.data.value),
                 items: [],
+                totalCount: 0,
                 page: set(state.page, ['offset'], 0),
             };
         case PROJECTS.SET_FILTER_OPTION:
@@ -70,6 +71,7 @@ export const projects = (
                     action.data.value
                 ),
                 items: [],
+                totalCount: 0,
                 page: set(state.page, ['offset'], 0),
             };
         case PROJECTS.CLEAR_FILTERS:
@@ -77,6 +79,7 @@ export const projects = (
                 ...state,
                 filters: {},
                 items: [],
+                totalCount: 0,
                 page: set(state.page, ['offset'], 0),
             };
 

--- a/frontend/src/modules/samples/reducers.js
+++ b/frontend/src/modules/samples/reducers.js
@@ -95,6 +95,7 @@ export const samples = (
                 ...state,
                 filters: set(state.filters, [action.data.name, 'value'], action.data.value),
                 items: [],
+                totalCount: 0,
                 page: set(state.page, ['offset'], 0),
             };
         case SAMPLES.SET_FILTER_OPTION:
@@ -106,6 +107,7 @@ export const samples = (
                     action.data.value
                 ),
                 items: [],
+                totalCount: 0,
                 page: set(state.page, ['offset'], 0),
             };
         case SAMPLES.CLEAR_FILTERS:
@@ -113,6 +115,7 @@ export const samples = (
                 ...state,
                 filters: {},
                 items: [],
+                totalCount: 0,
                 page: set(state.page, ['offset'], 0),
             };
 

--- a/frontend/src/modules/users/reducers.js
+++ b/frontend/src/modules/users/reducers.js
@@ -28,6 +28,7 @@ export const users = (
         ...state,
         filters: set(state.filters, [action.data.name, 'value'], action.data.value),
         items: [],
+        totalCount: 0,
         page: set(state.page, ['offset'], 0),
       };
     case USERS.SET_FILTER_OPTION:
@@ -35,6 +36,7 @@ export const users = (
         ...state,
         filters: set(state.filters, [action.data.name, 'options'], action.data.options),
         items: [],
+        totalCount: 0,
         page: set(state.page, ['offset'], 0),
       };
     case USERS.CLEAR_FILTERS:
@@ -42,6 +44,7 @@ export const users = (
         ...state,
         filters: {},
         items: [],
+        totalCount: 0,
         page: set(state.page, ['offset'], 0),
       };
 

--- a/frontend/src/utils/serializeFilterParams.js
+++ b/frontend/src/utils/serializeFilterParams.js
@@ -65,7 +65,8 @@ export default function serializeFilterParams(filters, descriptions) {
        break;
      }
 
-      case FILTER_TYPE.INPUT_NUMBER: {
+      case FILTER_TYPE.INPUT_NUMBER:
+      case FILTER_TYPE.INPUT_OBJECT_ID:   {
         if(value) {
           key += "__in"
           params[key] = value


### PR DESCRIPTION
This is a quick fix that solves the immediate problem of a bad filter value causing an infinite loop of requests from a PaginatedTable, but which just makes the whole system a bit more complicated and difficult to understand. This could be merged if a better fix is going to take a long time to implement.