### PR TITLE
Fix project details crash rendering pool samples

### DIFF
--- a/frontend/src/components/projects/ProjectsAssociatedSamples.js
+++ b/frontend/src/components/projects/ProjectsAssociatedSamples.js
@@ -21,7 +21,7 @@ const getTableColumns = (sampleKinds, individualsByID) => [
       width: 70,
       options: sampleKinds.items.map(x => ({ label: x.name, value: x.name })), // for getFilterProps
       render: (_, sample) =>
-        <Tag>{sampleKinds.itemsByID[sample.sample_kind].name}</Tag>,
+        {return sample.sample_kind && <Tag>{sampleKinds.itemsByID[sample.sample_kind].name}</Tag>}
     },
     {
       title: "Name",


### PR DESCRIPTION
Rendering a pool in the list of samples displayed in the project details page would cause the app to crash, because the `sample_kind` property of a pool sample is undefined.

This fix just adds a check for the `sample_kind` property before rendering the Tag for the sample kind.