### PR TITLE
distinct() on project queryset. Hide index for pools in sample details.

### DIFF
--- a/backend/fms_core/viewsets/project.py
+++ b/backend/fms_core/viewsets/project.py
@@ -14,7 +14,7 @@ from ._constants import _project_filterset_fields
 
 
 class ProjectViewSet(viewsets.ModelViewSet, TemplateActionsMixin):
-    queryset = Project.objects.all()
+    queryset = Project.objects.all().distinct()
     serializer_class = ProjectSerializer
 
     ordering_fields = (

--- a/frontend/src/components/samples/details/SampleDetailsContent.js
+++ b/frontend/src/components/samples/details/SampleDetailsContent.js
@@ -255,9 +255,10 @@ const SampleDetailsContent = ({
                 <Descriptions.Item label="Library Type">{library?.library_type}</Descriptions.Item>
                 <Descriptions.Item label="Platform">{library?.platform}</Descriptions.Item>
                 <Descriptions.Item label="Index">
-                  <Link to={`/samples/${sample.extracted_from}`}>
+                  {library?.index && 
+                  <Link to={`/indices/${library?.index}`}>
                     {withIndex(indicesByID, library?.index, index => index.name, "Loading...")}
-                  </Link>
+                  </Link>}
                 </Descriptions.Item>
                 <Descriptions.Item label="Library Size (bp)">{library?.library_size}</Descriptions.Item>
                 <Descriptions.Item label="Concentration (nM)">{library?.concentration_nm && concentration_nm}</Descriptions.Item>


### PR DESCRIPTION
Issues were there was many projects for pool in related projects tab and the index would be loading for pools in the sample detail.
