### PR TITLE
Removed useHashUrl from TemplatePreview

### DIFF
--- a/frontend/src/components/templateFlow/TemplatePreview.js
+++ b/frontend/src/components/templateFlow/TemplatePreview.js
@@ -2,12 +2,10 @@ import React from "react";
 import {Popover, Table, Tabs, Badge} from "antd";
 import {WarningOutlined} from "@ant-design/icons";
 import innerHTMLPurified from "../../utils/innerHTMLPurified";
-import useHashURL from "../../hooks/useHashURL";
 const {TabPane} = Tabs;
 
 
 export const TemplatePreview = ({checkResult}) => {
-  const [activeKey, setActiveKey] = useHashURL(0)
  return <>
     <p>
        {checkResult?.error?.message}
@@ -17,7 +15,7 @@ export const TemplatePreview = ({checkResult}) => {
           {baseError.error}
         </p>)
     }
-    <Tabs activeKey={activeKey} onChange={setActiveKey} size="large" type="card">
+    <Tabs size="large" type="card">
       {checkResult.result_previews?.map((preview, index) =>
          <TabPane tab={preview.name} key={index}>
                 {!checkResult.valid && renderResultWithErrors(preview)}


### PR DESCRIPTION
Removed hash url's from the TemplatePreview Tabs component.

There were two problems:
1. We are using integer values as TabPane keys, but the Tabs component doesn't render the first tab if the active key is set to zero.
2. The hash remains in the url if the user navigates back to the upload "page" (by clicking the Previous button), which is weird. The best fix for that would be to use separate routes for the different states of the TemplateFlow component (UPLOAD/REVIEW/CONFIRM), but that would be a major change.
