### PR TITLE
Fixes lineage graph navigation

### DIFF
--- a/frontend/src/components/processMeasurements/ProcessMeasurementsDetailContent.js
+++ b/frontend/src/components/processMeasurements/ProcessMeasurementsDetailContent.js
@@ -1,7 +1,6 @@
 import React, { useEffect } from "react";
-import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import { Descriptions, Typography, Tabs } from "antd";
 const { TabPane } = Tabs;
 const { Title } = Typography;
@@ -21,7 +20,6 @@ const mapStateToProps = state => ({
   propertyValuesByID: state.propertyValues.itemsByID,
   protocolsByID: state.protocols.itemsByID,
   samplesByID: state.samples.itemsByID,
-  usersByID: state.users.itemsByID,
 });
 
 const actionCreators = { get, listPropertyValues };
@@ -31,11 +29,9 @@ const ProcessMeasurementsDetailContent = ({
   propertyValuesByID,
   protocolsByID,
   samplesByID,
-  usersByID,
   get,
   listPropertyValues
 }) => {
-  const history = useNavigate();
   const { id } = useParams();
   const [activeKey, setActiveKey] = useHashURL('overview')
   const isLoaded = id in processMeasurementsByID;

--- a/frontend/src/components/samples/details/SampleDetailsContent.js
+++ b/frontend/src/components/samples/details/SampleDetailsContent.js
@@ -131,6 +131,22 @@ const SampleDetailsContent = ({
   const [sampleMetadata, setSampleMetadata] = useState([])
   const [activeKey, setActiveKey] = useHashURL('overview')
 
+
+  // Navigate to a sample when the sample's node is clicked in the lineage graph.
+  const navigateToSample = (sample_id) => {
+    if (sample_id) {
+      history(`/samples/${sample_id}#lineage`)
+    }
+  }
+
+  // Navigate to a process measurement when the user clicks an edge
+  // in the lineage graph.
+  const navigateToProcess = (process_id) => {
+    if (process_id) {
+      history(`/process-measurements/${process_id}`)
+    }
+  }
+
   // TODO: This spams API requests
   if (!samplesByID[id])
     getSample(id);
@@ -329,22 +345,8 @@ const SampleDetailsContent = ({
 
         <TabPane tab={`Lineage`} key="lineage" style={tabStyle}>
           <SampleDetailsLineage sample={sample} 
-            handleSampleClick={
-              // Navigate to another sample in the lineage graph
-              (sample_id) => {
-                if (sample_id) {
-                  history(`/samples/${sample_id}#lineage`)
-                }
-              }
-            }
-            handleProcessClick={
-              // Navigate to the process measurement details page
-              (process_id) => {
-                if (process_id) {
-                  history(`/process-measurements/${process_id}`)
-                }
-              }
-            }
+            handleSampleClick={navigateToSample}
+            handleProcessClick={navigateToProcess}
           />
         </TabPane>
 

--- a/frontend/src/components/samples/details/SampleDetailsContent.js
+++ b/frontend/src/components/samples/details/SampleDetailsContent.js
@@ -328,7 +328,24 @@ const SampleDetailsContent = ({
         </TabPane>
 
         <TabPane tab={`Lineage`} key="lineage" style={tabStyle}>
-          <SampleDetailsLineage sample={sample} tabPaneKey="lineage"/>
+          <SampleDetailsLineage sample={sample} 
+            handleSampleClick={
+              // Navigate to another sample in the lineage graph
+              (sample_id) => {
+                if (sample_id) {
+                  history(`/samples/${sample_id}#lineage`)
+                }
+              }
+            }
+            handleProcessClick={
+              // Navigate to the process measurement details page
+              (process_id) => {
+                if (process_id) {
+                  history(`/process-measurements/${process_id}`)
+                }
+              }
+            }
+          />
         </TabPane>
 
         <TabPane tab={`Pool`} key="pool" style={tabStyle}>

--- a/frontend/src/components/samples/details/SampleDetailsContent.js
+++ b/frontend/src/components/samples/details/SampleDetailsContent.js
@@ -328,10 +328,10 @@ const SampleDetailsContent = ({
         </TabPane>
 
         <TabPane tab={`Lineage`} key="lineage" style={tabStyle}>
-          <SampleDetailsLineage sample={sample}/>
+          <SampleDetailsLineage sample={sample} tabPaneKey="lineage"/>
         </TabPane>
 
-        <TabPane tab="Pool" key="7" style={tabStyle}>
+        <TabPane tab={`Pool`} key="pool" style={tabStyle}>
           <SampleDetailsPool sample={sample}></SampleDetailsPool>
         </TabPane>
       </Tabs>

--- a/frontend/src/components/samples/details/SampleDetailsLineage.js
+++ b/frontend/src/components/samples/details/SampleDetailsLineage.js
@@ -70,16 +70,18 @@ const SampleDetailsLineage = ({
   let dx = 0
   let dy = 0
   if (nodes.length > 0 && sample?.id !== undefined) {
-    const enclosedWidth = Math.max(...nodes.map((n) => n.x))
+    // Find the node that matches the current sample.
+    const currentNode = nodes.find((n) => n.id === sample.id.toString())
+    if (currentNode) {
+      const enclosedWidth = Math.max(...nodes.map((n) => n.x))
+      const { x: cx, y: cy } = currentNode
 
-    // find position of current node
-    const { x: cx, y: cy } = nodes.find((n) => n.id === sample.id.toString())
-
-    // if graph too wide
-    if (enclosedWidth > (graphSize.width - nodeSize.width)) {
-      dx = graphSize.width / 2 - cx
+        // if graph too wide
+      if (enclosedWidth > (graphSize.width - nodeSize.width)) {
+        dx = graphSize.width / 2 - cx
+      }
+      dy = (graphSize.height) / 2 - cy
     }
-    dy = (graphSize.height) / 2 - cy
   }
   const adjustedGraphData = {
     nodes: nodes.map((n) => ({

--- a/frontend/src/components/samples/details/SampleDetailsLineage.js
+++ b/frontend/src/components/samples/details/SampleDetailsLineage.js
@@ -189,8 +189,8 @@ const SampleDetailsLineage = ({
             </Button>
           </Popover>
         </Space>
-        <div ref={resizeRef} style={{ height: "100%", width: "100%", position: "absolute" }} className='PARENT-DIV'>
-          <div style={{ ...graphSize, border: "solid 1px gray" }} className='GRAPH-DIV'>
+        <div ref={resizeRef} style={{ height: "100%", width: "100%", position: "absolute" }}>
+          <div style={{ ...graphSize, border: "solid 1px gray" }}>
             {
               // graphData must contain at least one node
               // after fetching all nodes and edges

--- a/frontend/src/components/samples/details/SampleDetailsLineage.js
+++ b/frontend/src/components/samples/details/SampleDetailsLineage.js
@@ -20,9 +20,9 @@ const mapStateToProps = state => ({
 const SampleDetailsLineage = ({
   token,
   sample,
-  tabPaneKey  /* This key (should be 'lineage') is used to construct a url when the user clicks a node in the graph. */
+  handleSampleClick, // Function to navigate to a sample in the graph
+  handleProcessClick // Function to navigate to a process details page
 }) => {
-  const history = useNavigate()
   const { ref: resizeRef, size: maxSize } = useResizeObserver(720, 720)
 
   const [graphData, setGraphData] = useState({ nodes: [], links: [] })
@@ -204,10 +204,16 @@ const SampleDetailsLineage = ({
                     // tabPaneKey is used to generate a hash url for the lineage tab.
                     // Without the hash url, clicking a node navigates the user to the Overview tab
                     // rather than staying in the graph.
-                    onClickNode={(id, _) => history(`/samples/${id}#${tabPaneKey}`)}
+                    onClickNode={(id, _) => {
+                      if (id && handleSampleClick) {
+                        handleSampleClick(id)
+                      }
+                    }}
                     onClickLink={(source, target) => {
                       const linkId = nodesToEdges[`${source}:${target}`].id
-                      history(`/process-measurements/${linkId}`)
+                      if (linkId && handleProcessClick) {
+                        handleProcessClick(linkId)
+                      }
                     }}
                   />
                 : <Spin size={"large"} />

--- a/frontend/src/components/samples/details/SampleDetailsLineage.js
+++ b/frontend/src/components/samples/details/SampleDetailsLineage.js
@@ -14,14 +14,13 @@ import { useResizeObserver } from "../../../utils/ref"
 
 const mapStateToProps = state => ({
   token: state.auth.tokens.access,
-  samplesByID: state.samples.itemsByID,
-  processMeasurementsByID: state.processMeasurements.itemsByID,
-  protocolsByID: state.protocols.itemsByID,
 });
+
 
 const SampleDetailsLineage = ({
   token,
   sample,
+  tabPaneKey  /* This key (should be 'lineage') is used to construct a url when the user clicks a node in the graph. */
 }) => {
   const history = useNavigate()
   const { ref: resizeRef, size: maxSize } = useResizeObserver(720, 720)
@@ -190,8 +189,8 @@ const SampleDetailsLineage = ({
             </Button>
           </Popover>
         </Space>
-        <div ref={resizeRef} style={{ height: "100%", width: "100%", position: "absolute" }}>
-          <div style={{ ...graphSize, border: "solid 1px gray" }}>
+        <div ref={resizeRef} style={{ height: "100%", width: "100%", position: "absolute" }} className='PARENT-DIV'>
+          <div style={{ ...graphSize, border: "solid 1px gray" }} className='GRAPH-DIV'>
             {
               // graphData must contain at least one node
               // after fetching all nodes and edges
@@ -202,7 +201,10 @@ const SampleDetailsLineage = ({
                     id="graph-id"
                     data={adjustedGraphData}
                     config={graphConfig}
-                    onClickNode={(id, _) => history(`/samples/${id}`)}
+                    // tabPaneKey is used to generate a hash url for the lineage tab.
+                    // Without the hash url, clicking a node navigates the user to the Overview tab
+                    // rather than staying in the graph.
+                    onClickNode={(id, _) => history(`/samples/${id}#${tabPaneKey}`)}
                     onClickLink={(source, target) => {
                       const linkId = nodesToEdges[`${source}:${target}`].id
                       history(`/process-measurements/${linkId}`)

--- a/frontend/src/components/samples/details/SampleDetailsLineage.js
+++ b/frontend/src/components/samples/details/SampleDetailsLineage.js
@@ -1,6 +1,5 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { connect } from "react-redux";
-import { useNavigate } from "react-router-dom";
 
 import { Typography, Card, Space, Popover, Button, Spin } from 'antd';
 

--- a/frontend/src/hooks/useHashURL.js
+++ b/frontend/src/hooks/useHashURL.js
@@ -17,11 +17,12 @@ import { useCallback } from "react"
  * @param {*} defaultKey 
  * @returns 
  */
+
 export const useHashURL = (defaultKey) => {
     const history = useNavigate()
     const location = useLocation()
     const currentKey = location.hash.slice(1)
-    const setCurrentKey = useCallback((key) => { history(`#${key}`) }, [])
+    const setCurrentKey = (key) => { history(`#${key}`) }
     return [currentKey || defaultKey, setCurrentKey]
 }
 

--- a/frontend/src/hooks/useHashURL.js
+++ b/frontend/src/hooks/useHashURL.js
@@ -1,5 +1,4 @@
 import { useLocation, useNavigate } from "react-router-dom"
-import { useCallback } from "react"
 
 /**
  * This hook is used for managing a # hash url with the current location.

--- a/frontend/src/hooks/useHashURL.js
+++ b/frontend/src/hooks/useHashURL.js
@@ -22,12 +22,6 @@ export const useHashURL = (defaultKey) => {
     const location = useLocation()
     const currentKey = location.hash.slice(1)
     const setCurrentKey = useCallback((key) => { history(`#${key}`) }, [])
-    // If no key is currently in the url then add the default key automatically.
-    // This is just to keep the hash url's consistent when Tabs is first rendered.
-    if(!currentKey) {
-        setCurrentKey(defaultKey)
-    }
-
     return [currentKey || defaultKey, setCurrentKey]
 }
 


### PR DESCRIPTION
The new hash url feature broke lineage graph navigation. When the user clicks a node in the graph we navigate to the clicked sample. The url generated by the graph did not include the `#lineage` key, so the url would navigate the user to the Overview tab of the sample details page, rather than the lineage graph.

Now the sample url will include the `#lineage` key and the user will remain in the lineage graph.

To avoid problems in the future, I made the navigation functions props of SampleDetailsLineage to avoid having hard-coded links in the graph itself.

I also fixed the key for the Pool tab, which was still a number rather than "pool".

I cleaned up some dead code and useless imports I found in the code I touched.

In the urlHash code, I stopped setting the default hash key automatically because it was messing something up in the history which made it impossible to navigate from a process details page back to the lineage graph (clicking the back button didn't do anything - you would be stuck on the process details page).

Removed useCallback from useHaskKey and this was causing the tab view to route to stale url's unexpectedly.
