### PR TITLE
Fixed path to templates folder

### DIFF
--- a/backend/fms_core/tests/test_services/experiment_run_info_test.py
+++ b/backend/fms_core/tests/test_services/experiment_run_info_test.py
@@ -23,7 +23,7 @@ from fms_core.services import experiment_run, sample
 from datetime import datetime
 
 
-TEMPLATES_DIR = Path(__file__).parent / "templates"
+TEMPLATES_DIR = Path(__file__).parent.parent / "service-templates"
 
 PROJECT_NAME = 'TEST_PROJECT'
 EXTERNAL_PROJECT_ID = 'HERCULES_ID'


### PR DESCRIPTION
I moved the templates for my experiment_run_info tests and forgot to update the path to the templates folder. This fixes the problem.