### PR TITLE
Global hideEmptySteps flag for study details

### DIFF
--- a/frontend/src/components/studies/StudyDetails.tsx
+++ b/frontend/src/components/studies/StudyDetails.tsx
@@ -5,9 +5,9 @@ import { Project, Study, Workflow } from '../../models/frontend_models'
 import { StudySampleList } from '../../models/study_samples'
 import { get as getProject } from '../../modules/projects/actions'
 import { get as getStudy } from '../../modules/studies/actions'
-import { flushStudySamples, getStudySamples } from '../../modules/studySamples/actions'
+import { flushStudySamples, getStudySamples, setHideEmptySteps } from '../../modules/studySamples/actions'
 import { get as getWorkflow } from '../../modules/workflows/actions'
-import { selectProjectsByID, selectStudiesByID, selectStudySamples, selectWorkflowsByID } from '../../selectors'
+import { selectHideEmptySteps, selectProjectsByID, selectStudiesByID, selectStudySamplesByID, selectWorkflowsByID } from '../../selectors'
 import StudySamples from '../studySamples/StudySamples'
 
 const { Title, Text } = Typography
@@ -21,15 +21,14 @@ const StudyDetails = ({studyId} : StudyDetailsProps) => {
     const projectsById = useAppSelector(selectProjectsByID)
     const studiesById = useAppSelector(selectStudiesByID)
     const workflowsById = useAppSelector(selectWorkflowsByID)
-    const studySamplesState = useAppSelector(selectStudySamples)
+    const studySamplesState = useAppSelector(selectStudySamplesByID)
 
     const [study, setStudy] = useState<Study>()
     const [workflow, setWorkflow] = useState<Workflow>()
     const [project, setProject] = useState<Project>()
-
     const [studySamples, setStudySamples] = useState<StudySampleList>()
 
-    const [hideEmpty, setHideEmpty] = useState(false)
+    const hideEmpty = useAppSelector(selectHideEmptySteps)
 
     useEffect(() => {
         if (!studyId) {
@@ -85,6 +84,10 @@ const StudyDetails = ({studyId} : StudyDetailsProps) => {
         return null
     }
 
+    function handleHideEmptySteps(hide: boolean) {
+        dispatch(setHideEmptySteps(hide))
+    }
+
     return (
         <>
             <Title level={4}>{`Study ${study?.letter ?? ''}`}</Title>
@@ -98,7 +101,7 @@ const StudyDetails = ({studyId} : StudyDetailsProps) => {
                 <Title level={4} style={{marginTop: '1.5rem'}}>Samples</Title>
                 <Space>
                     <Text>Hide empty steps</Text>
-                    <Switch checked={hideEmpty} onChange={setHideEmpty}></Switch>
+                    <Switch checked={hideEmpty} onChange={handleHideEmptySteps}></Switch>
                 </Space>
             </div>
             

--- a/frontend/src/modules/studySamples/actions.ts
+++ b/frontend/src/modules/studySamples/actions.ts
@@ -1,6 +1,6 @@
 import { FMSSample, FMSSampleNextStep } from '../../models/fms_api_models'
 import { buildStudySamplesFromWorkflow } from '../../models/study_samples'
-import { selectStudiesByID, selectStudySamples, selectWorkflowsByID } from '../../selectors'
+import { selectStudiesByID, selectStudySamplesByID, selectWorkflowsByID } from '../../selectors'
 import { AppDispatch, RootState } from '../../store'
 import { createNetworkActionTypes } from '../../utils/actions'
 import api from '../../utils/api'
@@ -9,12 +9,13 @@ import { list as listLibraries } from '../libraries/actions'
 
 export const GET_STUDY_SAMPLES = createNetworkActionTypes('STUDY_SAMPLES.GET_STUDY_SAMPLES')
 export const FLUSH_STUDY_SAMPLES = 'STUDY_SAMPLES.FLUSH_STUDY_SAMPLES'
+export const SET_HIDE_EMPTY_STEPS = 'STUDY_SAMPLES.SET_HIDE_EMPTY_STEPS'
 
 
 export const getStudySamples = (studyID : number) => {
 
 	 async function fetch(dispatch: AppDispatch, getState: () => RootState) {
-		const currentState = selectStudySamples(getState())
+		const currentState = selectStudySamplesByID(getState())
 		const existingState = currentState[studyID]
 		if (existingState?.isFetching) {
 			return
@@ -93,9 +94,18 @@ export function flushStudySamples(studyID: number) {
 	}
 }
 
+export function setHideEmptySteps(hide: boolean) {
+	return {
+		type: SET_HIDE_EMPTY_STEPS,
+		hideEmptySteps: hide
+	}
+}
+
 export default {
 	GET_STUDY_SAMPLES,
 	FLUSH_STUDY_SAMPLES,
+	SET_HIDE_EMPTY_STEPS,
 	getStudySamples,
 	flushStudySamples,
+	setHideEmptySteps,
 }

--- a/frontend/src/modules/studySamples/reducers.ts
+++ b/frontend/src/modules/studySamples/reducers.ts
@@ -4,55 +4,98 @@ import { FetchedState } from "../common";
 import STUDY_SAMPLES from './actions'
 
 /* 
-	The study samples state can handle multiple studies.
-	The state uses the study ID as a key, which maps to the study
-	samples state for that study.
+	The studySamples state is used by the study details page to list the
+	workflow steps in a study and the samples that are at each step.
+	
+	The step/samples data are stored as StudySampleList objects.
 
-	To get the study samples do:
-		const studySamples = useState(selectStudySamples)[studyID]?.data
+	To retrieve the StudySampleList for a study from the store, use the
+	selector selectStudySamplesByID, then use the study ID as a key to
+	get the StudySampleList.
+
+	Example:
+
+	const myStudySamples = useAppSelector(selectStudySamplesByID)[studyID]
+
+	The state also manages a flag that is used to show or hide steps containing
+	no samples in the study details page.
 */
+
+
+export type StudySamplesByID = {[key: number] : FetchedState<StudySampleList>}
+
 export interface StudySamplesState {
-	[key: number] : FetchedState<StudySampleList>
+	studySamplesById:  StudySamplesByID			// Object where keys are study IDs and values are StudySampleList objects
+	hideEmptySteps: boolean						// Global flag to show or hide empty steps in study detail pages
+}
+
+const INITIAL_STATE : StudySamplesState = {
+	studySamplesById: {},
+	hideEmptySteps: false
 }
 
 export const studySamples = (
-	state: StudySamplesState = {},
+	state: StudySamplesState = INITIAL_STATE,
 	action: AnyAction
 ) : StudySamplesState => {
 	switch(action.type) {
 		case STUDY_SAMPLES.GET_STUDY_SAMPLES.REQUEST: {
 			const studyID = action.meta.studyID
-			return {...state, [studyID]: {
-				isFetching: true,
-			}}
+			return {
+				...state,
+				studySamplesById: {
+					...state.studySamplesById, 
+					[studyID] : {
+						isFetching: true
+					}
+				}
+			}
 		}
 
 		case STUDY_SAMPLES.GET_STUDY_SAMPLES.RECEIVE: {
 			const studyID = action.meta.studyID
-			return {...state, [studyID]: {
-				isFetching: false,
-				data: action.meta.studySamples
-			}}
+			return {
+				...state,
+				studySamplesById: {
+					...state.studySamplesById,
+					[studyID] : {
+						isFetching: false,
+						data: action.meta.studySamples
+					}
+				}
+			}
 		}
 
 		case STUDY_SAMPLES.GET_STUDY_SAMPLES.ERROR: {
 			const studyID = action.meta.studyID
-			let studySamples = state[studyID]
+			let studySamples = state.studySamplesById[studyID]
 			if (studySamples) {
-				studySamples = {
-					...studySamples,
-					isFetching: false,
-					error: action.error
+				return {
+					...state,
+					studySamplesById: {
+						...state.studySamplesById,
+						[studyID] : {
+							...studySamples,
+							isFetching: false,
+							error: action.error
+						}
+					}
 				}
-				return {...state, [studyID]: studySamples}
 			}
 		}
 		case STUDY_SAMPLES.FLUSH_STUDY_SAMPLES: {
 			const newState = {
 				...state
 			}
-			delete newState[action.studyID]
+			delete newState.studySamplesById[action.studyID]
 			return newState
+		}
+
+		case STUDY_SAMPLES.SET_HIDE_EMPTY_STEPS: {
+			return {
+				...state,
+				hideEmptySteps: action.hideEmptySteps
+			}
 		}
 	}
 	return state

--- a/frontend/src/selectors.ts
+++ b/frontend/src/selectors.ts
@@ -1,6 +1,6 @@
 import { Index, ItemsByID, Library, Project, Protocol, ReferenceGenome, Sample, SampleKind, Study, Taxon, User, Workflow } from "./models/frontend_models"
 import { LabworkSummaryState } from "./modules/labwork/reducers"
-import { StudySamplesState } from "./modules/studySamples/reducers"
+import { StudySamplesByID, StudySamplesState } from "./modules/studySamples/reducers"
 import { RootState } from "./store"
 
 /*
@@ -29,7 +29,8 @@ export const selectProtocolsByID = (state: RootState) => state.protocols.itemsBy
 export const selectReferenceGenomesByID = (state: RootState) => state.referenceGenomes.itemsByID as ItemsByID<ReferenceGenome>
 export const selectSamplesByID = (state: RootState) => state.samples.itemsByID as ItemsByID<Sample>
 export const selectSampleKindsByID = (state: RootState) => state.sampleKinds.itemsByID as ItemsByID<SampleKind>
-export const selectStudySamples = (state: RootState) => state.studySamples as StudySamplesState
+export const selectStudySamplesByID = (state: RootState) => state.studySamples.studySamplesById as StudySamplesByID
+export const selectHideEmptySteps = (state: RootState) => state.studySamples.hideEmptySteps
 export const selectStudiesByID = (state: RootState) => state.studies.itemsByID as ItemsByID<Study>
 export const selectTaxonsByID = (state: RootState) => state.taxons.itemsByID as ItemsByID<Taxon>
 export const selectUsersByID = (state: RootState) => state.users.itemsByID as ItemsByID<User>


### PR DESCRIPTION
The study details page sample list has a switch to show or hide empty steps. Originally, this flag was a property of the study detail page. Now, the flag is stored in redux and shared by all study details view. It was irritating to have to keep flicking the switch separately for each study.