### PR TITLE
Sort protocols by workflow order

### DIFF
--- a/backend/fms_core/viewsets/sample_next_step.py
+++ b/backend/fms_core/viewsets/sample_next_step.py
@@ -173,8 +173,7 @@ class SampleNextStepViewSet(viewsets.ModelViewSet, TemplateActionsMixin, Templat
 
                 # Make sure that at least one workflow uses one of the steps for this protocol, since
                 # labwork doesn't need protocols that are not used by any workflow (Infinium...)
-                workflows = Workflow.objects.filter(steps__in=protocolSteps)
-                if (workflows.count() == 0):
+                if not Workflow.objects.filter(steps__in=protocolSteps).exists():
                     continue
                 
                 # Some protocols have no associated steps, so don't include those in labwork info.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,9 +10,8 @@
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@ant-design/icons": "^4.2.1",
-        "@reduxjs/toolkit": "^1.9.1",
         "@types/redux-logger": "^3.0.9",
-        "antd": "^4.18.8",
+        "antd": "4.22.7",
         "bowser": "^2.11.0",
         "cheerio": "^1.0.0-rc.9",
         "cross-fetch": "^3.1.5",
@@ -50,6 +49,7 @@
         "@babel/preset-env": "^7.19.1",
         "@babel/preset-react": "^7.10.4",
         "@babel/preset-typescript": "^7.18.6",
+        "@reduxjs/toolkit": "^1.9.1",
         "babel-loader": "^8.1.0",
         "babel-plugin-import": "^1.13.3",
         "babel-polyfill": "^6.26.0",
@@ -2139,6 +2139,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.1.tgz",
       "integrity": "sha512-HikrdY+IDgRfRYlCTGUQaiCxxDDgM1mQrRbZ6S1HFZX5ZYuJ4o8EstNmhTwHdPl2rTmLxzwSu0b3AyeyTlR+RA==",
+      "dev": true,
       "dependencies": {
         "immer": "^9.0.16",
         "redux": "^4.2.0",
@@ -2742,9 +2743,9 @@
       }
     },
     "node_modules/antd": {
-      "version": "4.21.6",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-4.21.6.tgz",
-      "integrity": "sha512-6sizu/2CT0ofxl0nEvWUg5x2z7UOXZV+OqNcnQvrp+nGYI3ySAyzu8rxPvWIoA7NIa3TYnbrFayGy2gAqDGpuA==",
+      "version": "4.22.7",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-4.22.7.tgz",
+      "integrity": "sha512-CMf5tYHtlhP1blYjwNTRsB7G/bocwKmIFHgYYk4pZNgo1kk/XnPPI2/MKRCXWc54wuCQQlnmL/2AKtE7HWaE8g==",
       "dependencies": {
         "@ant-design/colors": "^6.0.0",
         "@ant-design/icons": "^4.7.0",
@@ -2760,18 +2761,18 @@
         "rc-checkbox": "~2.3.0",
         "rc-collapse": "~3.3.0",
         "rc-dialog": "~8.9.0",
-        "rc-drawer": "~4.4.2",
+        "rc-drawer": "~5.1.0",
         "rc-dropdown": "~4.0.0",
-        "rc-field-form": "~1.26.1",
+        "rc-field-form": "~1.27.0",
         "rc-image": "~5.7.0",
         "rc-input": "~0.0.1-alpha.5",
-        "rc-input-number": "~7.3.0",
-        "rc-mentions": "~1.8.0",
-        "rc-menu": "~9.6.0",
-        "rc-motion": "^2.5.1",
+        "rc-input-number": "~7.3.5",
+        "rc-mentions": "~1.9.1",
+        "rc-menu": "~9.6.3",
+        "rc-motion": "^2.6.1",
         "rc-notification": "~4.6.0",
-        "rc-pagination": "~3.1.16",
-        "rc-picker": "~2.6.8",
+        "rc-pagination": "~3.1.17",
+        "rc-picker": "~2.6.10",
         "rc-progress": "~3.3.2",
         "rc-rate": "~2.9.0",
         "rc-resize-observer": "^1.2.0",
@@ -2780,10 +2781,10 @@
         "rc-slider": "~10.0.0",
         "rc-steps": "~4.1.0",
         "rc-switch": "~3.2.0",
-        "rc-table": "~7.25.0",
+        "rc-table": "~7.25.3",
         "rc-tabs": "~11.16.0",
         "rc-textarea": "~0.3.0",
-        "rc-tooltip": "~5.1.1",
+        "rc-tooltip": "~5.2.0",
         "rc-tree": "~5.6.5",
         "rc-tree-select": "~5.4.0",
         "rc-trigger": "^5.2.10",
@@ -6492,6 +6493,7 @@
       "version": "9.0.16",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.16.tgz",
       "integrity": "sha512-qenGE7CstVm1NrHQbMh8YaSzTZTFNP3zPqr3YU0S0UY441j4bJTg4A2Hh5KAhwgaiU6ZZ1Ar6y/2f4TblnMReQ==",
+      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -8562,13 +8564,14 @@
       }
     },
     "node_modules/rc-drawer": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-4.4.3.tgz",
-      "integrity": "sha512-FYztwRs3uXnFOIf1hLvFxIQP9MiZJA+0w+Os8dfDh/90X7z/HqP/Yg+noLCIeHEbKln1Tqelv8ymCAN24zPcfQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-5.1.0.tgz",
+      "integrity": "sha512-pU3Tsn99pxGdYowXehzZbdDVE+4lDXSGb7p8vA9mSmr569oc2Izh4Zw5vLKSe/Xxn2p5MSNbLVqD4tz+pK6SOw==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.6",
-        "rc-util": "^5.7.0"
+        "rc-motion": "^2.6.1",
+        "rc-util": "^5.21.2"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -8591,9 +8594,9 @@
       }
     },
     "node_modules/rc-field-form": {
-      "version": "1.26.7",
-      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-1.26.7.tgz",
-      "integrity": "sha512-CIb7Gw+DG9R+g4HxaDGYHhOjhjQoU2mGU4y+UM2+KQ3uRz9HrrNgTspGvNynn3UamsYcYcaPWZJmiJ6VklkT/w==",
+      "version": "1.27.4",
+      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-1.27.4.tgz",
+      "integrity": "sha512-PQColQnZimGKArnOh8V2907+VzDCXcqtFvHgevDLtqWc/P7YASb/FqntSmdS8q3VND5SHX3Y1vgMIzY22/f/0Q==",
       "dependencies": {
         "@babel/runtime": "^7.18.0",
         "async-validator": "^4.1.0",
@@ -8637,13 +8640,13 @@
       }
     },
     "node_modules/rc-input-number": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-7.3.4.tgz",
-      "integrity": "sha512-W9uqSzuvJUnz8H8vsVY4kx+yK51SsAxNTwr8SNH4G3XqQNocLVmKIibKFRjocnYX1RDHMND9FFbgj2h7E7nvGA==",
+      "version": "7.3.11",
+      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-7.3.11.tgz",
+      "integrity": "sha512-aMWPEjFeles6PQnMqP5eWpxzsvHm9rh1jQOWXExUEIxhX62Fyl/ptifLHOn17+waDG1T/YUb6flfJbvwRhHrbA==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.5",
-        "rc-util": "^5.9.8"
+        "rc-util": "^5.23.0"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -8651,16 +8654,16 @@
       }
     },
     "node_modules/rc-mentions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-1.8.0.tgz",
-      "integrity": "sha512-ch7yfMMvx2UXy+EvE4axm0Vp6VlVZ30WLrZtLtV/Eb1ty7rQQRzNzCwAHAMyw6tNKTMs9t9sF68AVjAzQ0rvJw==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-1.9.2.tgz",
+      "integrity": "sha512-uxb/lzNnEGmvraKWNGE6KXMVXvt8RQv9XW8R0Dqi3hYsyPiAZeHRCHQKdLARuk5YBhFhZ6ga55D/8XuY367g3g==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.6",
         "rc-menu": "~9.6.0",
         "rc-textarea": "^0.3.0",
         "rc-trigger": "^5.0.4",
-        "rc-util": "^5.0.1"
+        "rc-util": "^5.22.5"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -8668,9 +8671,9 @@
       }
     },
     "node_modules/rc-menu": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.6.0.tgz",
-      "integrity": "sha512-d26waws42U/rVwW/+rOE2FN9pX6wUc9bDy38vVQYoie6gE85auWIpl5oChGlnW6nE2epnTwUsgWl8ipOPgmnUA==",
+      "version": "9.6.4",
+      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.6.4.tgz",
+      "integrity": "sha512-6DiNAjxjVIPLZXHffXxxcyE15d4isRL7iQ1ru4MqYDH2Cqc5bW96wZOdMydFtGLyDdnmEQ9jVvdCE9yliGvzkw==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
@@ -8686,9 +8689,9 @@
       }
     },
     "node_modules/rc-motion": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.6.0.tgz",
-      "integrity": "sha512-1MDWA9+i174CZ0SIDenSYm2Wb9YbRkrexjZWR0CUFu7D6f23E8Y0KsTgk9NGOLJsGak5ELZK/Y5lOlf5wQdzbw==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.6.3.tgz",
+      "integrity": "sha512-xFLkes3/7VL/J+ah9jJruEW/Akbx5F6jVa2wG5o/ApGKQKSOd5FR3rseHLL9+xtJg4PmCwo6/1tqhDO/T+jFHA==",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
@@ -8899,14 +8902,14 @@
       }
     },
     "node_modules/rc-table": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.25.2.tgz",
-      "integrity": "sha512-/xhSJrJSNj2JnWih1N2EQ0wihqTlRBvt+0tm+hTO42poyLz4t7KfMMAQQhguesx8AHlzqB+ZPYbGH8PtTScK4Q==",
+      "version": "7.25.3",
+      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.25.3.tgz",
+      "integrity": "sha512-McsLJ2rg8EEpRBRYN4Pf9gT7ZNYnjvF9zrBpUBBbUX/fxk+eGi5ff1iPIhMyiHsH71/BmTUzX9nc9XqupD0nMg==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.5",
         "rc-resize-observer": "^1.1.0",
-        "rc-util": "^5.14.0",
+        "rc-util": "^5.22.5",
         "shallowequal": "^1.1.0"
       },
       "engines": {
@@ -8954,11 +8957,12 @@
       }
     },
     "node_modules/rc-tooltip": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-5.1.1.tgz",
-      "integrity": "sha512-alt8eGMJulio6+4/uDm7nvV+rJq9bsfxFDCI0ljPdbuoygUscbsMYb6EQgwib/uqsXQUvzk+S7A59uYHmEgmDA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-5.2.2.tgz",
+      "integrity": "sha512-jtQzU/18S6EI3lhSGoDYhPqNpWajMtS5VV/ld1LwyfrDByQpYmw/LW6U7oFXXLukjfDHQ7Ju705A82PRNFWYhg==",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
+        "classnames": "^2.3.1",
         "rc-trigger": "^5.0.0"
       },
       "peerDependencies": {
@@ -9035,13 +9039,12 @@
       }
     },
     "node_modules/rc-util": {
-      "version": "5.22.5",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.22.5.tgz",
-      "integrity": "sha512-awD2TGMGU97OZftT2R3JwrHWjR8k/xIwqjwcivPskciweUdgXE7QsyXkBKVSBHXS+c17AWWMDWuKWsJSheQy8g==",
+      "version": "5.27.2",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.27.2.tgz",
+      "integrity": "sha512-8XHRbeJOWlTR2Hk1K2xLaPOf7lZu+3taskAGuqOPccA676vB3ygrz3ZgdrA3wml40CzR9RlIEHDWwI7FZT3wBQ==",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
-        "react-is": "^16.12.0",
-        "shallowequal": "^1.1.0"
+        "react-is": "^16.12.0"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -9470,7 +9473,8 @@
     "node_modules/reselect": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.7.tgz",
-      "integrity": "sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A=="
+      "integrity": "sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A==",
+      "dev": true
     },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
@@ -12710,6 +12714,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.1.tgz",
       "integrity": "sha512-HikrdY+IDgRfRYlCTGUQaiCxxDDgM1mQrRbZ6S1HFZX5ZYuJ4o8EstNmhTwHdPl2rTmLxzwSu0b3AyeyTlR+RA==",
+      "dev": true,
       "requires": {
         "immer": "^9.0.16",
         "redux": "^4.2.0",
@@ -13235,9 +13240,9 @@
       }
     },
     "antd": {
-      "version": "4.21.6",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-4.21.6.tgz",
-      "integrity": "sha512-6sizu/2CT0ofxl0nEvWUg5x2z7UOXZV+OqNcnQvrp+nGYI3ySAyzu8rxPvWIoA7NIa3TYnbrFayGy2gAqDGpuA==",
+      "version": "4.22.7",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-4.22.7.tgz",
+      "integrity": "sha512-CMf5tYHtlhP1blYjwNTRsB7G/bocwKmIFHgYYk4pZNgo1kk/XnPPI2/MKRCXWc54wuCQQlnmL/2AKtE7HWaE8g==",
       "requires": {
         "@ant-design/colors": "^6.0.0",
         "@ant-design/icons": "^4.7.0",
@@ -13253,18 +13258,18 @@
         "rc-checkbox": "~2.3.0",
         "rc-collapse": "~3.3.0",
         "rc-dialog": "~8.9.0",
-        "rc-drawer": "~4.4.2",
+        "rc-drawer": "~5.1.0",
         "rc-dropdown": "~4.0.0",
-        "rc-field-form": "~1.26.1",
+        "rc-field-form": "~1.27.0",
         "rc-image": "~5.7.0",
         "rc-input": "~0.0.1-alpha.5",
-        "rc-input-number": "~7.3.0",
-        "rc-mentions": "~1.8.0",
-        "rc-menu": "~9.6.0",
-        "rc-motion": "^2.5.1",
+        "rc-input-number": "~7.3.5",
+        "rc-mentions": "~1.9.1",
+        "rc-menu": "~9.6.3",
+        "rc-motion": "^2.6.1",
         "rc-notification": "~4.6.0",
-        "rc-pagination": "~3.1.16",
-        "rc-picker": "~2.6.8",
+        "rc-pagination": "~3.1.17",
+        "rc-picker": "~2.6.10",
         "rc-progress": "~3.3.2",
         "rc-rate": "~2.9.0",
         "rc-resize-observer": "^1.2.0",
@@ -13273,10 +13278,10 @@
         "rc-slider": "~10.0.0",
         "rc-steps": "~4.1.0",
         "rc-switch": "~3.2.0",
-        "rc-table": "~7.25.0",
+        "rc-table": "~7.25.3",
         "rc-tabs": "~11.16.0",
         "rc-textarea": "~0.3.0",
-        "rc-tooltip": "~5.1.1",
+        "rc-tooltip": "~5.2.0",
         "rc-tree": "~5.6.5",
         "rc-tree-select": "~5.4.0",
         "rc-trigger": "^5.2.10",
@@ -16091,7 +16096,8 @@
     "immer": {
       "version": "9.0.16",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.16.tgz",
-      "integrity": "sha512-qenGE7CstVm1NrHQbMh8YaSzTZTFNP3zPqr3YU0S0UY441j4bJTg4A2Hh5KAhwgaiU6ZZ1Ar6y/2f4TblnMReQ=="
+      "integrity": "sha512-qenGE7CstVm1NrHQbMh8YaSzTZTFNP3zPqr3YU0S0UY441j4bJTg4A2Hh5KAhwgaiU6ZZ1Ar6y/2f4TblnMReQ==",
+      "dev": true
     },
     "immutable": {
       "version": "4.1.0",
@@ -17580,13 +17586,14 @@
       }
     },
     "rc-drawer": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-4.4.3.tgz",
-      "integrity": "sha512-FYztwRs3uXnFOIf1hLvFxIQP9MiZJA+0w+Os8dfDh/90X7z/HqP/Yg+noLCIeHEbKln1Tqelv8ymCAN24zPcfQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-5.1.0.tgz",
+      "integrity": "sha512-pU3Tsn99pxGdYowXehzZbdDVE+4lDXSGb7p8vA9mSmr569oc2Izh4Zw5vLKSe/Xxn2p5MSNbLVqD4tz+pK6SOw==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.6",
-        "rc-util": "^5.7.0"
+        "rc-motion": "^2.6.1",
+        "rc-util": "^5.21.2"
       }
     },
     "rc-dropdown": {
@@ -17601,9 +17608,9 @@
       }
     },
     "rc-field-form": {
-      "version": "1.26.7",
-      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-1.26.7.tgz",
-      "integrity": "sha512-CIb7Gw+DG9R+g4HxaDGYHhOjhjQoU2mGU4y+UM2+KQ3uRz9HrrNgTspGvNynn3UamsYcYcaPWZJmiJ6VklkT/w==",
+      "version": "1.27.4",
+      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-1.27.4.tgz",
+      "integrity": "sha512-PQColQnZimGKArnOh8V2907+VzDCXcqtFvHgevDLtqWc/P7YASb/FqntSmdS8q3VND5SHX3Y1vgMIzY22/f/0Q==",
       "requires": {
         "@babel/runtime": "^7.18.0",
         "async-validator": "^4.1.0",
@@ -17632,32 +17639,32 @@
       }
     },
     "rc-input-number": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-7.3.4.tgz",
-      "integrity": "sha512-W9uqSzuvJUnz8H8vsVY4kx+yK51SsAxNTwr8SNH4G3XqQNocLVmKIibKFRjocnYX1RDHMND9FFbgj2h7E7nvGA==",
+      "version": "7.3.11",
+      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-7.3.11.tgz",
+      "integrity": "sha512-aMWPEjFeles6PQnMqP5eWpxzsvHm9rh1jQOWXExUEIxhX62Fyl/ptifLHOn17+waDG1T/YUb6flfJbvwRhHrbA==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.5",
-        "rc-util": "^5.9.8"
+        "rc-util": "^5.23.0"
       }
     },
     "rc-mentions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-1.8.0.tgz",
-      "integrity": "sha512-ch7yfMMvx2UXy+EvE4axm0Vp6VlVZ30WLrZtLtV/Eb1ty7rQQRzNzCwAHAMyw6tNKTMs9t9sF68AVjAzQ0rvJw==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-1.9.2.tgz",
+      "integrity": "sha512-uxb/lzNnEGmvraKWNGE6KXMVXvt8RQv9XW8R0Dqi3hYsyPiAZeHRCHQKdLARuk5YBhFhZ6ga55D/8XuY367g3g==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.6",
         "rc-menu": "~9.6.0",
         "rc-textarea": "^0.3.0",
         "rc-trigger": "^5.0.4",
-        "rc-util": "^5.0.1"
+        "rc-util": "^5.22.5"
       }
     },
     "rc-menu": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.6.0.tgz",
-      "integrity": "sha512-d26waws42U/rVwW/+rOE2FN9pX6wUc9bDy38vVQYoie6gE85auWIpl5oChGlnW6nE2epnTwUsgWl8ipOPgmnUA==",
+      "version": "9.6.4",
+      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.6.4.tgz",
+      "integrity": "sha512-6DiNAjxjVIPLZXHffXxxcyE15d4isRL7iQ1ru4MqYDH2Cqc5bW96wZOdMydFtGLyDdnmEQ9jVvdCE9yliGvzkw==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
@@ -17669,9 +17676,9 @@
       }
     },
     "rc-motion": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.6.0.tgz",
-      "integrity": "sha512-1MDWA9+i174CZ0SIDenSYm2Wb9YbRkrexjZWR0CUFu7D6f23E8Y0KsTgk9NGOLJsGak5ELZK/Y5lOlf5wQdzbw==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.6.3.tgz",
+      "integrity": "sha512-xFLkes3/7VL/J+ah9jJruEW/Akbx5F6jVa2wG5o/ApGKQKSOd5FR3rseHLL9+xtJg4PmCwo6/1tqhDO/T+jFHA==",
       "requires": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
@@ -17812,14 +17819,14 @@
       }
     },
     "rc-table": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.25.2.tgz",
-      "integrity": "sha512-/xhSJrJSNj2JnWih1N2EQ0wihqTlRBvt+0tm+hTO42poyLz4t7KfMMAQQhguesx8AHlzqB+ZPYbGH8PtTScK4Q==",
+      "version": "7.25.3",
+      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.25.3.tgz",
+      "integrity": "sha512-McsLJ2rg8EEpRBRYN4Pf9gT7ZNYnjvF9zrBpUBBbUX/fxk+eGi5ff1iPIhMyiHsH71/BmTUzX9nc9XqupD0nMg==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.5",
         "rc-resize-observer": "^1.1.0",
-        "rc-util": "^5.14.0",
+        "rc-util": "^5.22.5",
         "shallowequal": "^1.1.0"
       }
     },
@@ -17849,11 +17856,12 @@
       }
     },
     "rc-tooltip": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-5.1.1.tgz",
-      "integrity": "sha512-alt8eGMJulio6+4/uDm7nvV+rJq9bsfxFDCI0ljPdbuoygUscbsMYb6EQgwib/uqsXQUvzk+S7A59uYHmEgmDA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-5.2.2.tgz",
+      "integrity": "sha512-jtQzU/18S6EI3lhSGoDYhPqNpWajMtS5VV/ld1LwyfrDByQpYmw/LW6U7oFXXLukjfDHQ7Ju705A82PRNFWYhg==",
       "requires": {
         "@babel/runtime": "^7.11.2",
+        "classnames": "^2.3.1",
         "rc-trigger": "^5.0.0"
       }
     },
@@ -17904,13 +17912,12 @@
       }
     },
     "rc-util": {
-      "version": "5.22.5",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.22.5.tgz",
-      "integrity": "sha512-awD2TGMGU97OZftT2R3JwrHWjR8k/xIwqjwcivPskciweUdgXE7QsyXkBKVSBHXS+c17AWWMDWuKWsJSheQy8g==",
+      "version": "5.27.2",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.27.2.tgz",
+      "integrity": "sha512-8XHRbeJOWlTR2Hk1K2xLaPOf7lZu+3taskAGuqOPccA676vB3ygrz3ZgdrA3wml40CzR9RlIEHDWwI7FZT3wBQ==",
       "requires": {
         "@babel/runtime": "^7.18.3",
-        "react-is": "^16.12.0",
-        "shallowequal": "^1.1.0"
+        "react-is": "^16.12.0"
       }
     },
     "rc-virtual-list": {
@@ -18228,7 +18235,8 @@
     "reselect": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.7.tgz",
-      "integrity": "sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A=="
+      "integrity": "sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A==",
+      "dev": true
     },
     "resize-observer-polyfill": {
       "version": "1.5.1",

--- a/frontend/src/components/labwork/LabworkPage.tsx
+++ b/frontend/src/components/labwork/LabworkPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { Route, Routes } from 'react-router-dom'
 import { useAppDispatch, useAppSelector } from '../../hooks'
 import { flushLabworkSummary, getLabworkSummary } from '../../modules/labwork/actions'
-import { selectLabworkSummaryState } from '../../selectors'
+import { selectAppInitialzed, selectLabworkSummaryState } from '../../selectors'
 import ActionContent from '../ActionContent'
 import PageContainer from '../PageContainer'
 import LabworkOverviewRoute from './overview/LabworkOverviewRoute'
@@ -14,18 +14,21 @@ const LabworkPage = () => {
 	// is loaded no matter which route is selected.
 	const [loading, setLoading] = useState(false)
 	const labworkSummaryState = useAppSelector(selectLabworkSummaryState)
+	const appInitialized = useAppSelector(selectAppInitialzed)
 	const dispatch = useAppDispatch()
 
 	useEffect(() => {
 		if (labworkSummaryState.summary) {
 			setLoading(false)
 		} else {
-			if (!loading && !labworkSummaryState.isFetching) {
+			// The summary can't be loaded until the workflow definitions have been loaded during
+			// app initialization.
+			if (!loading && appInitialized && !labworkSummaryState.isFetching) {
 				setLoading(true)
 				dispatch(getLabworkSummary())
 			}
 		}
-	}, [labworkSummaryState])
+	}, [appInitialized, labworkSummaryState])
 
 	useEffect(() => {
 		// Flush the labwork state when the user navigates away from the

--- a/frontend/src/components/labwork/overview/LabworkOverviewProtocols.tsx
+++ b/frontend/src/components/labwork/overview/LabworkOverviewProtocols.tsx
@@ -1,9 +1,10 @@
 import { SyncOutlined } from '@ant-design/icons'
 import { Button, Collapse, Space, Switch, Typography } from 'antd'
 import React from 'react'
-import { useAppDispatch } from '../../../hooks'
+import { useAppDispatch, useAppSelector } from '../../../hooks'
 import { LabworkSummary } from '../../../models/labwork_summary'
 import { refreshLabwork, setHideEmptyProtocols } from '../../../modules/labwork/actions'
+import { selectWorkflowsByID } from '../../../selectors'
 import LabworkOverviewProtocolPanel from './LabworkOverviewProtocolPanel'
 
 const { Title } = Typography
@@ -15,13 +16,13 @@ interface LabworkProtocolsProps {
 
 const LabworkOverviewProtocols = ({ summary, hideEmptyProtocols }: LabworkProtocolsProps) => {
 	const dispatch = useAppDispatch()
+	const workflowsByID = useAppSelector(selectWorkflowsByID)
 
 	// If hideEmptyProtocols is true then we filter the protocol list to include
 	// only protocols with a count greater than zero.
 	let protocols = summary.protocols
 
-	// Sort protocols by name (the endpoint returns them in random order)
-	protocols = protocols.sort((a, b) => a.name.localeCompare(b.name))
+	const workflows = Object.values(workflowsByID)
 
 	if (hideEmptyProtocols) {
 		protocols = protocols.filter(protocol => protocol.count > 0)

--- a/frontend/src/modules/labwork/actions.ts
+++ b/frontend/src/modules/labwork/actions.ts
@@ -1,4 +1,4 @@
-import { selectLabworkSummaryState } from '../../selectors'
+import { selectLabworkSummaryState, selectProtocolsByID, selectWorkflowsByID } from '../../selectors'
 import { createNetworkActionTypes } from '../../utils/actions'
 import api from '../../utils/api'
 import { refreshSamplesAtStep } from '../labworkSteps/actions'
@@ -17,9 +17,11 @@ export const getLabworkSummary = () => async (dispatch, getState) => {
 
 	dispatch({type: GET_LABWORK_SUMMARY.REQUEST})
 
+	const workflows = Object.values(selectWorkflowsByID(getState()))
+
 	try {
 		const response = await dispatch(api.sampleNextStep.labworkSummary())
-		const summary = processFMSLabworkSummary(response.data.results)
+		const summary = processFMSLabworkSummary(response.data.results, workflows)
 		dispatch({
 			type: GET_LABWORK_SUMMARY.RECEIVE,
 			data: summary

--- a/frontend/src/modules/labwork/services.ts
+++ b/frontend/src/modules/labwork/services.ts
@@ -229,15 +229,16 @@ function getSortedProtocolsFromWorkflows(workflows: Workflow[]): FMSId[] {
 		// if A is normally before or after B in the sort order.
 		if (entriesA && entriesB) {
 			for(const entryA of entriesA) {
-				// Find and occurence of B in the same workflow as A
-				const entryB = entriesB.find(entry => entry.workflowID === entryA.workflowID)
-				if (entryB) {
+				// The same protocol can appear multiple times, so we have to check each instance
+				// of B in the workflow
+				const allBEntriesInWorkflow = entriesB.filter(entry => entry.workflowID === entryA.workflowID)
+				allBEntriesInWorkflow.forEach(entryB => {
 					if (entryA.stepOrder < entryB.stepOrder) {
 						numBefore++
 					} else {
 						numAfter++
 					}
-				}
+				})
 			}
 
 			// If numBefore and numberAfter are both zero then there was no case where both A and B
@@ -247,7 +248,7 @@ function getSortedProtocolsFromWorkflows(workflows: Workflow[]): FMSId[] {
 			// The idea is to figure out if the protocol appears near the beginning of workflows or near
 			// the end. Without this, rarely used protocols tend to end up at the top of the list 
 			// (eg DBNSEQ Preparation).
-			if (numBefore === 0 && numAfter === 0) {
+			if (numBefore === 0 && numAfter === 0 && entriesA.length > 0 && entriesB.length > 0) {
 				const distanceA = entriesA.reduce((acc, entry) => {
 					return acc + (entry.stepOrder / entry.numSteps)
 				}, 0) / entriesA.length

--- a/frontend/src/modules/labwork/services.ts
+++ b/frontend/src/modules/labwork/services.ts
@@ -1,12 +1,18 @@
-import { FMSId, FMSLabworkSummary } from "../../models/fms_api_models"
+import { FMSId, FMSLabworkSummary, WorkflowStep } from "../../models/fms_api_models"
+import { Workflow } from "../../models/frontend_models"
 import { LabworkStepGroup, LabworkSummary, LabworkSummaryProtocol, LabworkSummaryStep } from "../../models/labwork_summary"
+
+
+let sortedProtocols: FMSId[] = []
 
 /**
  * Processes the labwork summary data received from the backend, adding step grouping.
  * @param fmsSummary FMSLabworkSummary
  * @returns LabworkSummary
  */
-export function processFMSLabworkSummary(fmsSummary: FMSLabworkSummary): LabworkSummary {
+export function processFMSLabworkSummary(
+	fmsSummary: FMSLabworkSummary,
+	workflows: Workflow[]): LabworkSummary {
 	
 	const result: LabworkSummary = {
 		protocols: []
@@ -85,10 +91,23 @@ export function processFMSLabworkSummary(fmsSummary: FMSLabworkSummary): Labwork
 		}		
 
 		result.protocols.push(protocol)
-
-		// TODO : sort the protocols? By which criteria? Ideally it would match the basic
-		// order of steps in the workflows somehow.
 	}
+
+	// If we haven't built the sorted protocol list yet, then build it. It's
+	// expensive so it should only be done once.
+	if (sortedProtocols.length === 0) {
+		sortedProtocols = getSortedProtocolsFromWorkflows(workflows)
+	}
+	result.protocols = result.protocols.sort((a, b) => {
+		// Get the position of the protocols in the sorted protocol array and
+		// use that to compare a and b.
+		const indexA = sortedProtocols.findIndex(protocolID => protocolID === a.id)
+		const indexB = sortedProtocols.findIndex(protocolID => protocolID === b.id)
+		if (indexA === -1 || indexB === -1) {
+			return 0
+		}
+		return indexA - indexB
+	})
 
 	return result
 }
@@ -154,4 +173,98 @@ export function findChangedStepsInSummary(oldSummary: LabworkSummary, newSummary
 	}
 
 	return changedStepIDs
+}
+
+/**
+ * Figure out the sorting for order for all of the protocols used in the workflows.
+ * We look compare each protocol to all the other protocols in the workflow to figure
+ * out which ones it usually follows, and which ones it usually preceeds. * 
+ * @param protocols 
+ * @param workflows 
+ * @returns 
+ */
+function getSortedProtocolsFromWorkflows(workflows: Workflow[]): FMSId[] {
+
+	// Sorting has to scan all steps across all workflows. To avoid doing this more than once,
+	// we gather information about where in each workflow a protocol is used. The map key is
+	// the protocol id, and one entry is created for each step that is found using that protocol.
+	// It's gnarly code! Sorry, but my first implementation had to traverse the workflows several times.
+	type ProtocolEntry = {
+		workflowID: FMSId
+		stepOrder: number
+		numSteps: number
+		step: WorkflowStep
+	}
+
+	const workflowOccurences = new Map<FMSId, ProtocolEntry[]>()
+
+	workflows.forEach(workflow => {
+		workflow.steps_order.forEach(step => {
+			const entry : ProtocolEntry = {
+				workflowID: workflow.id,
+				stepOrder: step.order,
+				numSteps: workflow.steps_order.length,
+				step: step
+			}
+			const list = workflowOccurences.get(step.protocol_id)
+			if (list) {
+				list.push(entry)
+			} else {
+				workflowOccurences.set(step.protocol_id, [entry])
+			}
+		})
+	})
+
+	
+	function compareProtocolPositionsInWorkflows(protocolID_A: FMSId, protocolID_B: FMSId) {
+		const entriesA = workflowOccurences.get(protocolID_A)
+		const entriesB = workflowOccurences.get(protocolID_B)
+
+		let numBefore = 0
+		let numAfter = 0
+
+		// Compare the position of protocol A with the position of protocol B in each
+		// workflow that contains the two. Count the number of times that A appears after
+		// B in the workflow, and the number of time A appears before B. Use that to decide
+		// if A is normally before or after B in the sort order.
+		if (entriesA && entriesB) {
+			for(const entryA of entriesA) {
+				// Find and occurence of B in the same workflow as A
+				const entryB = entriesB.find(entry => entry.workflowID === entryA.workflowID)
+				if (entryB) {
+					if (entryA.stepOrder < entryB.stepOrder) {
+						numBefore++
+					} else {
+						numAfter++
+					}
+				}
+			}
+
+			// If numBefore and numberAfter are both zero then there was no case where both A and B
+			// are used in the same workflow, so we can't compare their positions in the workflow.
+			// Instead, compute an average "distance" for A and B. This is the step order divided by
+			// the number of steps in the workflow, averaged over all workflows the protocol appears in.
+			// The idea is to figure out if the protocol appears near the beginning of workflows or near
+			// the end. Without this, rarely used protocols tend to end up at the top of the list 
+			// (eg DBNSEQ Preparation).
+			if (numBefore === 0 && numAfter === 0) {
+				const distanceA = entriesA.reduce((acc, entry) => {
+					return acc + (entry.stepOrder / entry.numSteps)
+				}, 0) / entriesA.length
+				const distanceB = entriesB.reduce((acc, entry) => {
+					return acc + (entry.stepOrder / entry.numSteps)
+				}, 0) / entriesB.length
+
+				return distanceA - distanceB
+			} else {
+				return numAfter - numBefore
+			}
+		}
+		return 0
+	}
+
+	const protocolIDs = [...workflowOccurences.keys()]
+	const sortedProtocolIDs = protocolIDs.sort(compareProtocolPositionsInWorkflows)
+
+	return sortedProtocolIDs
 }


### PR DESCRIPTION
Display protocols in the labwork overview page in a sensible order - the order in which they normally appear in workflows.

The idea is to look at each protocol and see which protocols it should follow and which it should precede based on where it appears in the workflows.

This gets done once, the first time the labwork is fetched from the backend, after the app is initialized and all the workflow definitions have been loaded.

I also tweaked the labwork-info endpoint in sample_next_step to avoid returning info about steps that are not used in any workflow - I was getting an Infinium protocol that is not used in any workflow and always had zero samples.