### PR TITLE
Fix step grouping 1564

### DIFF
--- a/frontend/src/components/labwork/overview/LabworkOverviewStepGroup.tsx
+++ b/frontend/src/components/labwork/overview/LabworkOverviewStepGroup.tsx
@@ -11,7 +11,7 @@ interface LabworkOverviewStepGroupProps {
 }
 
 const LabworkOverviewStepGroup = ({ group, hideEmptySteps }: LabworkOverviewStepGroupProps) => {
-	const renderNamedGroup = group.defaultGroup === false && group.steps.length > 1 && !!group.name
+	const renderNamedGroup = group.defaultGroup === false && !!group.name
 	let listData = group.steps
 	if (hideEmptySteps) {
 		listData = listData.filter(step => step.count > 0)

--- a/frontend/src/modules/labwork/services.ts
+++ b/frontend/src/modules/labwork/services.ts
@@ -36,8 +36,8 @@ export function processFMSLabworkSummary(fmsSummary: FMSLabworkSummary): Labwork
 		if (protocol.name === 'Library Preparation') {
 
 			// Create a group for each platform
-			const groups = new Map<string, LabworkStepGroup>()
-			groups.set('UNKNOWN', {
+			const groupsMap = new Map<string, LabworkStepGroup>()
+			groupsMap.set('UNKNOWN', {
 				defaultGroup: false,
 				name: 'UNKNOWN',
 				steps: []
@@ -48,16 +48,16 @@ export function processFMSLabworkSummary(fmsSummary: FMSLabworkSummary): Labwork
 				let group
 				const platform = getSpecifiedValue(step, 'Library Platform')
 				if (platform) {
-					if (!groups.has(platform)) {
-						groups.set(platform, {
+					if (!groupsMap.has(platform)) {
+						groupsMap.set(platform, {
 							defaultGroup: false,
 							name: platform,
 							steps: []
 						})
 					}
-					group = groups.get(platform)
+					group = groupsMap.get(platform)
 				} else {
-					group = groups.get('UNKNOWN')
+					group = groupsMap.get('UNKNOWN')
 				}
 				if (group) {
 					group.steps.push(step)
@@ -65,7 +65,7 @@ export function processFMSLabworkSummary(fmsSummary: FMSLabworkSummary): Labwork
 			}
 
 			// Sort the groups by group name (since the order of items in the map is random)
-			const sortedGroups =  [...groups.values()]
+			const sortedGroups =  [...groupsMap.values()]
 				.sort((groupA, groupB) => {
 					if (!groupA.name || !groupB.name) {
 						return 0


### PR DESCRIPTION
Library Preparation steps are grouped by platform (ILLUMINA, DBNSEQ). The "DBNSEQ" group title wasn't being displayed. This PR fixes that. The group title is always displayed, even if there is only a single step in the group.