### PR TITLE
Don't disable labwork on refresh

### DIFF
--- a/frontend/src/components/labwork/overview/LabworkOverview.tsx
+++ b/frontend/src/components/labwork/overview/LabworkOverview.tsx
@@ -10,12 +10,17 @@ interface LabworkOverviewProps {
 }
 
 const LabworkOverview = ({state} : LabworkOverviewProps) => {	
+
+	// Only display loading indicator on initial load, not during every refresh.
+	const loading = state.isFetching && !state.summary
+	const refreshing = state.isFetching
 	return (
 		<>
-			<AppPageHeader title="Lab Work" />				
-			<PageContent loading={state.isFetching} style={{maxWidth: '50rem'} as any}>
+			<AppPageHeader title="Lab Work" />
+
+			<PageContent loading={loading} style={{maxWidth: '50rem'} as any}>
 				{state.summary && 
-					<LabworkOverviewProtocols summary={state.summary} hideEmptyProtocols={state.hideEmptyProtocols}/>
+					<LabworkOverviewProtocols summary={state.summary} hideEmptyProtocols={state.hideEmptyProtocols} refreshing={refreshing}/>
 				}
 			</PageContent>
 		</>

--- a/frontend/src/components/labwork/overview/LabworkOverviewProtocols.tsx
+++ b/frontend/src/components/labwork/overview/LabworkOverviewProtocols.tsx
@@ -10,10 +10,11 @@ const { Title } = Typography
 
 interface LabworkProtocolsProps {
 	summary: LabworkSummary,
-	hideEmptyProtocols: boolean
+	hideEmptyProtocols: boolean,
+	refreshing: boolean
 }
 
-const LabworkOverviewProtocols = ({ summary, hideEmptyProtocols }: LabworkProtocolsProps) => {
+const LabworkOverviewProtocols = ({ summary, hideEmptyProtocols, refreshing }: LabworkProtocolsProps) => {
 	const dispatch = useAppDispatch()
 
 	// If hideEmptyProtocols is true then we filter the protocol list to include
@@ -33,7 +34,7 @@ const LabworkOverviewProtocols = ({ summary, hideEmptyProtocols }: LabworkProtoc
 				<Title level={2}>Protocols</Title>
 				<Space>
 					<Switch checkedChildren={'Show all'} unCheckedChildren={'Hide Empty'} checked={hideEmptyProtocols} onChange={value => dispatch(setHideEmptyProtocols(value))}/>
-					<Button icon={<SyncOutlined/>} onClick={
+					<Button icon={<SyncOutlined spin={refreshing}/>} disabled={refreshing} onClick={
 						() => {
 							// Refreshes labwork and step samples states
 							dispatch(refreshLabwork())

--- a/frontend/src/components/labwork/step/LabworkStep.tsx
+++ b/frontend/src/components/labwork/step/LabworkStep.tsx
@@ -61,7 +61,7 @@ const LabworkStep = ({ protocol, step, stepSamples }: LabworkStepPageProps) => {
 		dispatch(setSortBy(step.id, sortBy))
 	}
 
-	const canRefresh = true
+	const isRefreshing = stepSamples.pagedItems.isFetching
 	function handleRefresh() {
 		dispatch(refreshSamplesAtStep(step.id))
 	}
@@ -143,7 +143,7 @@ const LabworkStep = ({ protocol, step, stepSamples }: LabworkStepPageProps) => {
 		<Space>
 			<Button type='primary' disabled={!canPrefill} onClick={handlePrefillTemplate} title='Download a prefilled template with the selected samples'>Prefill Template</Button>
 			<Button type='default' disabled={!canSubmit} onClick={handleSubmitTemplate} title='Submit a prefilled template'>Submit Template</Button>
-			<Button icon={<SyncOutlined/>}title='Refresh the list of samples' disabled={!canRefresh} onClick={() => handleRefresh()}>Refresh</Button>
+			<Button icon={<SyncOutlined spin={isRefreshing}/>}title='Refresh the list of samples' disabled={isRefreshing} onClick={() => handleRefresh()}>Refresh</Button>
 		</Space>
 	)
 


### PR DESCRIPTION
In the labwork overview page, the page would be dimmed every 30 seconds when the labwork is refreshed. Now the page is only dimmed if the labwork summary hasn't been loaded yet.

I also adding spinning to the Refresh buttons in the labwork and step pages to indicate when the page is being refresh.