### PR TITLE
Generate filter options dynamically

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -13,17 +13,28 @@ module.exports = {
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
         "ecmaVersion": "latest",
+        "ecmaFeatures": {
+            "jsx": true
+        },
         "sourceType": "module"
     },
     "plugins": [
         "react",
+        "react-hooks",
         "@typescript-eslint",
     ],
+    "settings": {
+        "react": {
+            "version": "detect"
+        }
+    },
     // Ignore dot '.' files in project folder
     "ignorePatterns": ["\.*"],
     "rules": {
         "no-empty": "warn",
         "react/prop-types": "off",
+        "react-hooks/rules-of-hooks": "error",
+        "react-hooks/exhaustive-deps": "warn",
         "no-mixed-spaces-and-tabs": "off",
         "@typescript-eslint/no-empty-interface": "off",
         "@typescript-eslint/no-explicit-any": "off",

--- a/frontend/.tsconfig
+++ b/frontend/.tsconfig
@@ -7,9 +7,16 @@
     "strict": true,
     "isolatedModules": true,
     "esModuleInterop": true,
-    "sourceMaps": true
+    "sourceMap": true,
+    "jsx": "preserve",
+    "noImplicitAny": false
   },
   "include": [
-    "src"
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
   ]
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -75,6 +75,7 @@
     "cypress-file-upload": "^5.0.2",
     "eslint": "^8.24.0",
     "eslint-plugin-react": "^7.31.8",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "git-revision-webpack-plugin": "^3.0.6",
     "html-webpack-plugin": "^5.3.1",
     "style-loader": "^1.1.3",

--- a/frontend/src/components/labwork/LabworkPage.tsx
+++ b/frontend/src/components/labwork/LabworkPage.tsx
@@ -28,7 +28,7 @@ const LabworkPage = () => {
 				dispatch(getLabworkSummary())
 			}
 		}
-	}, [appInitialized, labworkSummaryState])
+	}, [loading, appInitialized, labworkSummaryState, dispatch])
 
 	useEffect(() => {
 		// Flush the labwork state when the user navigates away from the
@@ -36,7 +36,7 @@ const LabworkPage = () => {
 		return () => {
 			dispatch(flushLabworkSummary())
 		}
-	}, [])
+	}, [dispatch])
 
 	return (
 		<PageContainer>

--- a/frontend/src/components/labwork/overview/LabworkOverviewProtocols.tsx
+++ b/frontend/src/components/labwork/overview/LabworkOverviewProtocols.tsx
@@ -1,10 +1,9 @@
 import { SyncOutlined } from '@ant-design/icons'
 import { Button, Collapse, Space, Switch, Typography } from 'antd'
 import React from 'react'
-import { useAppDispatch, useAppSelector } from '../../../hooks'
+import { useAppDispatch } from '../../../hooks'
 import { LabworkSummary } from '../../../models/labwork_summary'
 import { refreshLabwork, setHideEmptyProtocols } from '../../../modules/labwork/actions'
-import { selectWorkflowsByID } from '../../../selectors'
 import LabworkOverviewProtocolPanel from './LabworkOverviewProtocolPanel'
 
 const { Title } = Typography
@@ -17,13 +16,10 @@ interface LabworkProtocolsProps {
 
 const LabworkOverviewProtocols = ({ summary, hideEmptyProtocols, refreshing }: LabworkProtocolsProps) => {
 	const dispatch = useAppDispatch()
-	const workflowsByID = useAppSelector(selectWorkflowsByID)
 
 	// If hideEmptyProtocols is true then we filter the protocol list to include
 	// only protocols with a count greater than zero.
 	let protocols = summary.protocols
-
-	const workflows = Object.values(workflowsByID)
 
 	if (hideEmptyProtocols) {
 		protocols = protocols.filter(protocol => protocol.count > 0)

--- a/frontend/src/components/labwork/step/LabworkStep.tsx
+++ b/frontend/src/components/labwork/step/LabworkStep.tsx
@@ -1,6 +1,6 @@
 import { InfoCircleOutlined, SyncOutlined } from '@ant-design/icons'
 import { Alert, Button, Select, Space, Tabs, Typography } from 'antd'
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAppDispatch } from '../../../hooks'
 import { FMSId } from '../../../models/fms_api_models'
@@ -43,55 +43,64 @@ const LabworkStep = ({ protocol, step, stepSamples }: LabworkStepPageProps) => {
 		}
 	}, [stepSamples])
 
-	function handleSetFilter(filterKey: string, value: FilterValue, description: FilterDescription) {
-		if(typeof description === 'undefined') {
-			return
-		}
-		dispatch(setFilter(step.id, description, value))
-	}
+	const handleSetFilter = useCallback(
+		(filterKey: string, value: FilterValue, description: FilterDescription) => {
+			if(typeof description === 'undefined') {
+				return
+			}
+			dispatch(setFilter(step.id, description, value))
+		}, []
+	)
 
-	function handleSetFilterOptions(filterKey: string, property: string, value: boolean, description: FilterDescription) {
-		if(typeof description === 'undefined') {
-			return
+	const handleSetFilterOptions = useCallback(
+		(filterKey: string, property: string, value: boolean, description: FilterDescription) => {
+			if(typeof description === 'undefined') {
+				return
+			}
+			dispatch(setFilterOptions(step.id, description, {[property]: value}))
 		}
-		dispatch(setFilterOptions(step.id, description, {[property]: value}))
-	}
-
-	function handleSetSortBy(sortBy: SortBy) {
-		dispatch(setSortBy(step.id, sortBy))
-	}
+	, [])
+		
+	const handleSetSortBy = useCallback(
+		(sortBy: SortBy) => {
+			dispatch(setSortBy(step.id, sortBy))
+		}
+	, [])
 
 	const isRefreshing = stepSamples.pagedItems.isFetching
-	function handleRefresh() {
-		dispatch(refreshSamplesAtStep(step.id))
-	}
+	const handleRefresh = useCallback(
+		() => {dispatch(refreshSamplesAtStep(step.id))}	
+	, [])
 
 	// Handle the prefill template button
 	const canPrefill = selectedTemplate && stepSamples.selectedSamples.length > 0
 
-	async function handlePrefillTemplate() {
-		// Generate a prefilled template containing the list of selected values.		
-		if (selectedTemplate) {
-			try {
-				const result = await dispatch(requestPrefilledTemplate(selectedTemplate.id, step.id))
-				if (result) {
-					downloadFromFile(result.filename, result.data)
+	const handlePrefillTemplate = useCallback(
+		async () => {
+			if (selectedTemplate) {
+				try {
+					const result = await dispatch(requestPrefilledTemplate(selectedTemplate.id, step.id))
+					if (result) {
+						downloadFromFile(result.filename, result.data)
+					}
+				} catch(err) {
+					console.error(err)
 				}
-			} catch(err) {
-				console.error(err)
 			}
 		}
-	}
-	
+	, [])
+
 	// Submit Template handler
 	const canSubmit = selectedTemplate && selectedTemplate.submissionURL
 
-	function handleSubmitTemplate() {
-		dispatch(flushSamplesAtStep(step.id))
-		if (selectedTemplate && selectedTemplate.submissionURL) {
-			navigate(selectedTemplate.submissionURL)
+	const handleSubmitTemplate = useCallback(
+		() => {
+			dispatch(flushSamplesAtStep(step.id))
+			if (selectedTemplate && selectedTemplate.submissionURL) {
+				navigate(selectedTemplate.submissionURL)
+			}
 		}
-	}
+	, [])
 
 	// When the user selects or deselects samples in the table, the table gives us the new selection.
 	// The selection, however, only covers the page of samples that are currently displayed in the table.
@@ -119,7 +128,7 @@ const LabworkStep = ({ protocol, step, stepSamples }: LabworkStepPageProps) => {
 	// Selection handler for sample selection checkboxes
 	const selectionProps = {
 		selectedSampleIDs: stepSamples.selectedSamples,
-		onSelectionChanged: (selectedSamples) => {
+		onSelectionChanged: useCallback((selectedSamples) => {
 			const displayedSelection = selectedSamples.reduce((acc, selected) => {
 				if (selected.sample) {
 					acc.push(selected.sample.id)
@@ -128,13 +137,15 @@ const LabworkStep = ({ protocol, step, stepSamples }: LabworkStepPageProps) => {
 			}, [] as FMSId[])
 			const mergedSelection = mergeSelectionChange(stepSamples.selectedSamples, stepSamples.displayedSamples, displayedSelection)
 			dispatch(updateSelectedSamplesAtStep(step.id, mergedSelection))
-		},
+		}, []),
 	}
 
 	const canClearSelection = stepSamples.selectedSamples.length !== 0
-	function handleClearSelection() {
-		dispatch(clearSelectedSamples(step.id))
-	}
+	const handleClearSelection = useCallback(
+		() => {
+			dispatch(clearSelectedSamples(step.id))
+		}
+	, [])
 
 	// Display the number of selected samples in the tab title
 	const selectedTabTitle = `Selection (${stepSamples.selectedSamples.length} ${stepSamples.selectedSamples.length === 1 ? "sample" : "samples"} selected)`
@@ -147,14 +158,18 @@ const LabworkStep = ({ protocol, step, stepSamples }: LabworkStepPageProps) => {
 		</Space>
 	)
 
-	function handlePageNumber(pageNumber: number) {
-		dispatch(loadSamplesAtStep(step.id, pageNumber))
-	}
+	const handlePageNumber = useCallback(
+		(pageNumber: number) => {
+			dispatch(loadSamplesAtStep(step.id, pageNumber))
+		}
+	, [])
 
-	function handlePageSize(pageSize: number) {
-		dispatch(setPageSize(pageSize))
-		dispatch(loadSamplesAtStep(step.id, stepSamples.pagedItems.page?.pageNumber ?? 1))
-	}
+	const handlePageSize = useCallback(
+		(pageSize: number) => {
+			dispatch(setPageSize(pageSize))
+			dispatch(loadSamplesAtStep(step.id, stepSamples.pagedItems.page?.pageNumber ?? 1))
+		}
+	, [])
 
 	const pagination: PaginationParameters = {
 		pageNumber: stepSamples.pagedItems.page?.pageNumber ?? 1,
@@ -163,6 +178,20 @@ const LabworkStep = ({ protocol, step, stepSamples }: LabworkStepPageProps) => {
 		onChangePageNumber: handlePageNumber,
 		onChangePageSize: handlePageSize
 	}
+
+	// Memoizing these cuts down on table re-renders. Without it, the samples tables render 6 times
+	// when they are initially visible.
+	const columnsForStep = useMemo(() => {
+		return getColumnsForStep(step, protocol)
+	}, [step, protocol])
+
+	const filterDefinitions = useMemo(() => {
+		return {...SAMPLE_COLUMN_FILTERS, ...LIBRARY_COLUMN_FILTERS}
+	}, [])
+
+	const filterKeys = useMemo(() => {
+		return {...SAMPLE_NEXT_STEP_FILTER_KEYS, ...SAMPLE_NEXT_STEP_LIBRARY_FILTER_KEYS}
+	}, [])
 
 	return (
 		<>
@@ -199,9 +228,9 @@ const LabworkStep = ({ protocol, step, stepSamples }: LabworkStepPageProps) => {
 					<Tabs.TabPane tab='Samples' key='samples'>
 						<WorkflowSamplesTable 
 							sampleIDs={stepSamples.displayedSamples} 
-							columns={getColumnsForStep(step, protocol)}
-							filterDefinitions={{...SAMPLE_COLUMN_FILTERS, ...LIBRARY_COLUMN_FILTERS}}
-							filterKeys={{...SAMPLE_NEXT_STEP_FILTER_KEYS, ...SAMPLE_NEXT_STEP_LIBRARY_FILTER_KEYS}}
+							columns={columnsForStep}
+							filterDefinitions={filterDefinitions}
+							filterKeys={filterKeys}
 							filters={stepSamples.pagedItems.filters}
 							setFilter={handleSetFilter}
 							setFilterOptions={handleSetFilterOptions}
@@ -225,7 +254,7 @@ const LabworkStep = ({ protocol, step, stepSamples }: LabworkStepPageProps) => {
 						{/* Selection table does not allow filtering or sorting */}
 						<WorkflowSamplesTable 
 							sampleIDs={stepSamples.selectedSamples}
-							columns={getColumnsForStep(step, protocol)}
+							columns={columnsForStep}
 							filterDefinitions={{}}
 							filterKeys={{}}
 							filters={{}}

--- a/frontend/src/components/labwork/step/LabworkStep.tsx
+++ b/frontend/src/components/labwork/step/LabworkStep.tsx
@@ -31,7 +31,7 @@ const LabworkStep = ({ protocol, step, stepSamples }: LabworkStepPageProps) => {
 	const dispatch = useAppDispatch()
 	const navigate = useNavigate()
 
-	// Set the currently selected template to the first template available, not already set.
+	// Set the currently selected template to the first template available, if not already set.
 	useEffect(() => {
 		if(!selectedTemplate) {
 			if (stepSamples.prefill.templates.length > 0) {
@@ -41,7 +41,7 @@ const LabworkStep = ({ protocol, step, stepSamples }: LabworkStepPageProps) => {
 				console.error('No templates are associated with step!')
 			}
 		}
-	}, [stepSamples])
+	}, [stepSamples, selectedTemplate])
 
 	const handleSetFilter = useCallback(
 		(filterKey: string, value: FilterValue, description: FilterDescription) => {
@@ -49,7 +49,7 @@ const LabworkStep = ({ protocol, step, stepSamples }: LabworkStepPageProps) => {
 				return
 			}
 			dispatch(setFilter(step.id, description, value))
-		}, []
+		}, [step, dispatch]
 	)
 
 	const handleSetFilterOptions = useCallback(
@@ -59,18 +59,18 @@ const LabworkStep = ({ protocol, step, stepSamples }: LabworkStepPageProps) => {
 			}
 			dispatch(setFilterOptions(step.id, description, {[property]: value}))
 		}
-	, [])
+	, [step, dispatch])
 		
 	const handleSetSortBy = useCallback(
 		(sortBy: SortBy) => {
 			dispatch(setSortBy(step.id, sortBy))
 		}
-	, [])
+	, [step, dispatch])
 
 	const isRefreshing = stepSamples.pagedItems.isFetching
 	const handleRefresh = useCallback(
 		() => {dispatch(refreshSamplesAtStep(step.id))}	
-	, [])
+	, [step, dispatch])
 
 	// Handle the prefill template button
 	const canPrefill = selectedTemplate && stepSamples.selectedSamples.length > 0
@@ -88,7 +88,7 @@ const LabworkStep = ({ protocol, step, stepSamples }: LabworkStepPageProps) => {
 				}
 			}
 		}
-	, [])
+	, [step, selectedTemplate, dispatch])
 
 	// Submit Template handler
 	const canSubmit = selectedTemplate && selectedTemplate.submissionURL
@@ -100,7 +100,7 @@ const LabworkStep = ({ protocol, step, stepSamples }: LabworkStepPageProps) => {
 				navigate(selectedTemplate.submissionURL)
 			}
 		}
-	, [])
+	, [step, selectedTemplate, navigate, dispatch])
 
 	// When the user selects or deselects samples in the table, the table gives us the new selection.
 	// The selection, however, only covers the page of samples that are currently displayed in the table.
@@ -137,7 +137,7 @@ const LabworkStep = ({ protocol, step, stepSamples }: LabworkStepPageProps) => {
 			}, [] as FMSId[])
 			const mergedSelection = mergeSelectionChange(stepSamples.selectedSamples, stepSamples.displayedSamples, displayedSelection)
 			dispatch(updateSelectedSamplesAtStep(step.id, mergedSelection))
-		}, []),
+		}, [step, stepSamples, dispatch]),
 	}
 
 	const canClearSelection = stepSamples.selectedSamples.length !== 0
@@ -145,7 +145,7 @@ const LabworkStep = ({ protocol, step, stepSamples }: LabworkStepPageProps) => {
 		() => {
 			dispatch(clearSelectedSamples(step.id))
 		}
-	, [])
+	, [step, dispatch])
 
 	// Display the number of selected samples in the tab title
 	const selectedTabTitle = `Selection (${stepSamples.selectedSamples.length} ${stepSamples.selectedSamples.length === 1 ? "sample" : "samples"} selected)`
@@ -162,14 +162,14 @@ const LabworkStep = ({ protocol, step, stepSamples }: LabworkStepPageProps) => {
 		(pageNumber: number) => {
 			dispatch(loadSamplesAtStep(step.id, pageNumber))
 		}
-	, [])
+	, [step, dispatch])
 
 	const handlePageSize = useCallback(
 		(pageSize: number) => {
 			dispatch(setPageSize(pageSize))
 			dispatch(loadSamplesAtStep(step.id, stepSamples.pagedItems.page?.pageNumber ?? 1))
 		}
-	, [])
+	, [step, stepSamples, dispatch])
 
 	const pagination: PaginationParameters = {
 		pageNumber: stepSamples.pagedItems.page?.pageNumber ?? 1,

--- a/frontend/src/components/labwork/step/LabworkStepRoute.tsx
+++ b/frontend/src/components/labwork/step/LabworkStepRoute.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
-import { useParams } from 'react-router-dom'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
+import { useIDParam } from '../../../hooks/useIDParams'
 import { Protocol, Step } from '../../../models/frontend_models'
 import { initSamplesAtStep } from '../../../modules/labworkSteps/actions'
 import { LabworkStepSamples } from '../../../modules/labworkSteps/models'
@@ -12,8 +12,10 @@ import LabworkStep from './LabworkStep'
 	LabworkStepRoute is responsible for loading all of the labwork step samples
 	data. Once loaded, it renders a LabworkStep component to display the data.
 */
+
+
 const LabworkStepRoute = () => {
-	const stepIDParam = useParams().stepID
+	const stepID = useIDParam('stepID')
 	const appInitialized = useAppSelector(selectAppInitialzed)
 	const labworkStepsState = useAppSelector(selectLabworkStepsState)
 	const protocolsByID = useAppSelector(selectProtocolsByID)
@@ -24,15 +26,8 @@ const LabworkStepRoute = () => {
 	const [protocol, setProtocol] = useState<Protocol>()
 	const [labworkStepSamples, setLabworkStepSamples] = useState<LabworkStepSamples>()
 
-	// Bail if the step ID is missing from the URL - there's a problem.
-	if(!stepIDParam) {
-		console.error(`stepID parameter is missing from step page url`)
-		return null
-	}
-	const stepID = parseInt(stepIDParam)
-
 	useEffect(() => {
-		if (appInitialized) {
+		if (stepID && appInitialized) {
 			if(! step) {
 				const foundStep = stepsByID[stepID]
 				if(foundStep) {
@@ -40,7 +35,7 @@ const LabworkStepRoute = () => {
 				}
 			}
 		}
-	}, [appInitialized, stepsByID])
+	}, [appInitialized, stepsByID, stepID, step])
 
 	useEffect(() => {
 		if(step && !protocol) {
@@ -49,18 +44,18 @@ const LabworkStepRoute = () => {
 				setProtocol(foundProtocol)
 			}
 		}
-	}, [step, protocolsByID])
+	}, [step, protocolsByID, protocol])
 	
 	useEffect(() => {
 		if(step && protocol) {
-			const foundLabwork = labworkStepsState.steps[stepID]
+			const foundLabwork = labworkStepsState.steps[step.id]
 			if(foundLabwork) {
 				setLabworkStepSamples(foundLabwork)
 			} else {
-				dispatch(initSamplesAtStep(stepID))
+				dispatch(initSamplesAtStep(step.id))
 			}
 		}
-	}, [step, protocol, labworkStepsState])
+	}, [step, protocol, labworkStepsState, dispatch])
 
 	return (
 		step && protocol && labworkStepSamples ?

--- a/frontend/src/components/projects/ProjectsPage.js
+++ b/frontend/src/components/projects/ProjectsPage.js
@@ -4,10 +4,10 @@ import {Navigate, Route, Routes} from "react-router-dom";
 
 import ProjectsListContent from "./ProjectsListContent";
 import ProjectEditContent from "./ProjectEditContent";
-import ProjectsDetailedContent from "./ProjectsDetailedContent.tsx";
 import PageContainer from "../PageContainer";
 import ActionContent from "../ActionContent";
 import StudyEditContent from "../studies/StudyEditContent";
+import ProjectsDetailedContentRoute from "./ProjectsDetailedContent";
 
 const ProjectsPage = () => {
   return (
@@ -17,7 +17,7 @@ const ProjectsPage = () => {
         <Route path="/actions/:action/*" element={<ActionContent templateType="project" />}/>
         <Route path="/add/*" element={<ProjectEditContent />}/>
         <Route path="/:id/update/*" element={<ProjectEditContent />}/>
-        <Route path="/:id/*" element={<ProjectsDetailedContent/>}/>
+        <Route path="/:id/*" element={<ProjectsDetailedContentRoute/>}/>
         <Route path="/:id/study/add/*" element={<StudyEditContent action="ADD"/>}/>
         <Route path="/:id/study/:study_id/update" element={<StudyEditContent action="EDIT"/>}/>
         <Route path="*" element={<Navigate to="/projects/list" replace />}/>

--- a/frontend/src/components/shared/WithItemComponent.tsx
+++ b/frontend/src/components/shared/WithItemComponent.tsx
@@ -58,7 +58,7 @@ const WithItemComponent = <T extends FMSTrackedModel>({ withItem, objectsByID, o
 		if (result) {
 			setValue(fn(result))
 		}
-	}, [objectsByID, objectID])
+	}, [objectsByID, objectID, withItem, fn, defaultValue])
 
 	return value ? <>{value}</> : defaultValue ? <>{defaultValue}</> : null
 }

--- a/frontend/src/components/shared/WorkflowSamplesTable/MergeColumnsAndFilters.ts
+++ b/frontend/src/components/shared/WorkflowSamplesTable/MergeColumnsAndFilters.ts
@@ -42,6 +42,14 @@ export function addFiltersToColumns<T>(
 
 			const filterValue = filters[key]
 
+			// If the filter has a function to generate options dynamically then call it.
+			if (filter.dynamicOptions) {
+				filter = {
+					...filter,
+					options: filter.dynamicOptions()
+				}
+			}
+
 			const props = getFilterPropsForDescription(column, filter, filterValue, setFilter, setFilterOption)
 
 			return {

--- a/frontend/src/components/shared/WorkflowSamplesTable/SampleTableColumns.tsx
+++ b/frontend/src/components/shared/WorkflowSamplesTable/SampleTableColumns.tsx
@@ -4,6 +4,8 @@ import { Link } from 'react-router-dom'
 import { FILTER_TYPE } from '../../../constants'
 import { Sample } from '../../../models/frontend_models'
 import { FilterDescription } from '../../../models/paged_items'
+import { selectSampleKindsByID } from '../../../selectors'
+import store from '../../../store'
 import { Depletion } from '../../Depletion'
 import { QCFlag } from '../../QCFlag'
 import SampleKindTag from '../../SampleKindTag'
@@ -199,6 +201,19 @@ export const SAMPLE_COLUMN_DEFINITIONS: { [key in SampleColumnID]: SampleColumn 
 
 export const UNDEFINED_FILTER_KEY = 'UNDEFINED_FILTER_KEY'
 
+// Initializes the sample KIND options with the sample kinds in the redux store.
+function getSampleKindOptions() {
+	const sampleKinds = selectSampleKindsByID(store.getState())
+	const options = Object.values(sampleKinds).map((sampleKind) => {
+		return {
+			label: sampleKind.name,
+			value: sampleKind.name
+
+		}
+	})
+	return options
+}
+
 export const SAMPLE_COLUMN_FILTERS: { [key in SampleColumnID]: FilterDescription } = {
 	// Object keys map to column "columnID" properties, to match columns to filters.
 	[SampleColumnID.ID]: {
@@ -212,6 +227,7 @@ export const SAMPLE_COLUMN_FILTERS: { [key in SampleColumnID]: FilterDescription
 		label: 'Type',
 		mode: 'multiple',
 		placeholder: 'All',
+		dynamicOptions: getSampleKindOptions
 	},
 	[SampleColumnID.NAME]: {
 		type: FILTER_TYPE.INPUT,

--- a/frontend/src/components/shared/WorkflowSamplesTable/SampleTableColumns.tsx
+++ b/frontend/src/components/shared/WorkflowSamplesTable/SampleTableColumns.tsx
@@ -204,14 +204,16 @@ export const UNDEFINED_FILTER_KEY = 'UNDEFINED_FILTER_KEY'
 // Initializes the sample KIND options with the sample kinds in the redux store.
 function getSampleKindOptions() {
 	const sampleKinds = selectSampleKindsByID(store.getState())
-	const options = Object.values(sampleKinds).map((sampleKind) => {
-		return {
-			label: sampleKind.name,
-			value: sampleKind.name
-
-		}
-	})
-	return options
+	if (sampleKinds) {
+		const options = Object.values(sampleKinds).map((sampleKind) => {
+			return {
+				label: sampleKind.name,
+				value: sampleKind.name
+	
+			}
+		})
+		return options
+	}return []
 }
 
 export const SAMPLE_COLUMN_FILTERS: { [key in SampleColumnID]: FilterDescription } = {

--- a/frontend/src/components/shared/WorkflowSamplesTable/WorkflowSamplesTable.tsx
+++ b/frontend/src/components/shared/WorkflowSamplesTable/WorkflowSamplesTable.tsx
@@ -1,6 +1,6 @@
 import { Pagination, Table, TableProps } from 'antd'
-import { RowSelectMethod, TableRowSelection } from 'antd/lib/table/interface'
-import React, { useEffect, useState } from 'react'
+import { TableRowSelection } from 'antd/lib/table/interface'
+import React, { useEffect, useMemo, useState } from 'react'
 import { useAppSelector } from '../../../hooks'
 import { FMSId } from '../../../models/fms_api_models'
 import { FilterDescriptionSet, FilterKeySet, FilterSet, SetFilterFunc, SetFilterOptionFunc, SetSortByFunc, SortBy } from '../../../models/paged_items'
@@ -34,11 +34,8 @@ interface WorkflowSamplesTableProps {
 	}
 }
 
-// TODO port StudySamples component to use this table.
 function WorkflowSamplesTable({sampleIDs, columns, filterDefinitions, filterKeys, filters, setFilter, setFilterOptions, sortBy, setSortBy, pagination, selection} : WorkflowSamplesTableProps) {
 	const [samples, setSamples] = useState<SampleAndLibrary[]>([])
-	const [tableColumns, setTableColumns] = useState<IdentifiedTableColumnType<SampleAndLibrary>[]>()
-
 	const samplesByID = useAppSelector(selectSamplesByID)
 	const librariesByID = useAppSelector(selectLibrariesByID)
 
@@ -59,11 +56,8 @@ function WorkflowSamplesTable({sampleIDs, columns, filterDefinitions, filterKeys
 		setSamples(availableSamples)
 	}, [samplesByID, librariesByID, sampleIDs])
 
-	useEffect(() => {
-		// Only construct the table columns when necessary.
-		// Ideally the columns would only need to be built once, but part of the process
-		// includes setting filter values in the filter components, so this code has
-		// be run whenever the filters change.
+
+	const tableColumns = useMemo(() => {
 		const mergedColumns = addFiltersToColumns(
 			columns, 
 			filterDefinitions ?? {},
@@ -71,8 +65,8 @@ function WorkflowSamplesTable({sampleIDs, columns, filterDefinitions, filterKeys
 			filters ?? {}, 
 			setFilter, 
 			setFilterOptions)
-		setTableColumns(mergedColumns)
-	}, [filters])
+		return mergedColumns
+	}, [filterDefinitions, filterKeys, filters])
 
 
 	let rowSelection: TableRowSelection<SampleAndLibrary> | undefined = undefined

--- a/frontend/src/components/shared/WorkflowSamplesTable/WorkflowSamplesTable.tsx
+++ b/frontend/src/components/shared/WorkflowSamplesTable/WorkflowSamplesTable.tsx
@@ -66,7 +66,7 @@ function WorkflowSamplesTable({sampleIDs, columns, filterDefinitions, filterKeys
 			setFilter, 
 			setFilterOptions)
 		return mergedColumns
-	}, [filterDefinitions, filterKeys, filters])
+	}, [columns, filterDefinitions, filterKeys, filters, setFilter, setFilterOptions])
 
 
 	let rowSelection: TableRowSelection<SampleAndLibrary> | undefined = undefined

--- a/frontend/src/components/shared/WorkflowSamplesTable/serializeFilterParamsTS.ts
+++ b/frontend/src/components/shared/WorkflowSamplesTable/serializeFilterParamsTS.ts
@@ -42,9 +42,9 @@ export default function serializeFilterParamsWithDescriptions(filters: FilterSet
 			case FILTER_TYPE.SELECT: {
 				key = description.mode === 'multiple' ? key + '__in' : key
 				if (isStringArrayFilterValue(value)) {
-					params[key] = [...(value.join(','))]
+					params[key] = value.join(',')
 				} else if (isStringFilterValue(value)) {
-					params[key] = [value]
+					params[key] = value
 				}
 				break
 			}

--- a/frontend/src/components/studies/StudyDetails.tsx
+++ b/frontend/src/components/studies/StudyDetails.tsx
@@ -57,13 +57,13 @@ const StudyDetails = ({studyId} : StudyDetailsProps) => {
             }
         }
 
-    }, [studiesById, workflowsById, projectsById, studySamplesState])
+    }, [studyId, studiesById, workflowsById, projectsById, studySamplesState, studySamples, dispatch])
 
     useEffect(() => {
         return () => {
             dispatch(flushStudySamples(studyId))
         }
-    }, [studyId])
+    }, [studyId, dispatch])
 
     function getStepWithOrder(order?: number) {
         if (order && study && workflow) {

--- a/frontend/src/components/studies/StudyEditContent.tsx
+++ b/frontend/src/components/studies/StudyEditContent.tsx
@@ -14,9 +14,7 @@ import PageContent from '../PageContent'
 import StudyEditForm from './StudyEditForm'
 
 
-interface EditStudyContentProps {
-	action: 'ADD' | 'EDIT'
-}
+
 
 interface AlertError {
 	message: string
@@ -28,9 +26,14 @@ export function createStudyTabKey(studyId : number) {
 	return `study-${studyId}`
 }
 
-const StudyEditContent = ({ action }: EditStudyContentProps) => {
+interface StudyEditContentProps {
+	action: 'ADD' | 'EDIT'
+}
+
+const StudyEditContent = ({ action }: StudyEditContentProps) => {
 	const navigate = useNavigate()
 	const dispatch = useAppDispatch()
+	const projectId = useIDParam('id')
 
 	const [alertError, setAlertError] = useState<AlertError>()
 	const [apiError, setApiError] = useState<ApiError>()
@@ -39,12 +42,6 @@ const StudyEditContent = ({ action }: EditStudyContentProps) => {
 	const isCreating = action === 'ADD'
 	
 	const projectsById : ItemsByID<Project> = useSelector(selectProjectsByID)
-
-
-	const projectId = useIDParam('id')
-	if (!projectId) {
-		return null
-	}
 	
 	useEffect(() => {
 		if (projectId) {
@@ -57,8 +54,6 @@ const StudyEditContent = ({ action }: EditStudyContentProps) => {
 		}
 	}, [projectId, projectsById])
 
-	
-
 	const workflowsByID = useSelector(selectWorkflowsByID)
 	const workflows = Object.values(workflowsByID) as Workflow[]
 
@@ -66,7 +61,7 @@ const StudyEditContent = ({ action }: EditStudyContentProps) => {
 	if (isCreating) {
 		title = 'Create a Study'
 	} else {
-		title = `Edit ${'a Study'}` // TODO: display study name
+		title = `Edit ${'a Study'}`
 	}
 
 	async function handleFormSubmit(workflow?: Workflow, stepRange?: WorkflowStepRange) {
@@ -82,7 +77,7 @@ const StudyEditContent = ({ action }: EditStudyContentProps) => {
 					setApiError(undefined)
 					if (studyData?.id) {
 						// Navigate to the study page
-						const url = `/projects/${projectId}#${createStudyTabKey(studyData.id)}`
+						const url = `/projects/${project.id}#${createStudyTabKey(studyData.id)}`
 						navigate(url)
 					}
 				}).catch((err) => {
@@ -98,7 +93,7 @@ const StudyEditContent = ({ action }: EditStudyContentProps) => {
 				console.log(result)
 			}
 		} else {
-			// TODO handle study update
+			// This is where we will handle editing an existing study.
 		}
 	}
 

--- a/frontend/src/models/frontend_models.ts
+++ b/frontend/src/models/frontend_models.ts
@@ -43,12 +43,26 @@ export interface ItemsByID<T extends FMSTrackedModel> {
 	[key: FMSId]: T
 }
 
+/**
+ * Generates an ItemsByID object from an array of model objects.
+ * @param items Array of model objects
+ * @returns ItemsByID
+ */
 export function createItemsByID<T extends FMSTrackedModel>(items: T[]) : ItemsByID<T> {
 	const itemsByID : ItemsByID<T> = {}
 	items.forEach(item => {
 		itemsByID[item.id] = item
 	})
 	return itemsByID
+}
+
+/**
+ * Gets all of the items from an ItemsByID object, as an array.
+ * @param itemsByID An ItemsByID object
+ * @returns The array of items contained in the ItemsByID object
+ */
+export function getAllItems<T extends FMSTrackedModel>(itemsByID: ItemsByID<T>) : T[] {
+	return Object.values(itemsByID) as T[]
 }
 
 export type ObjectId = FMSId

--- a/frontend/src/models/paged_items.ts
+++ b/frontend/src/models/paged_items.ts
@@ -1,4 +1,3 @@
-import { RootState } from "../store"
 import { FMSId, FMSTrackedModel } from "./fms_api_models"
 import { ItemsByID } from "./frontend_models"
 

--- a/frontend/src/models/paged_items.ts
+++ b/frontend/src/models/paged_items.ts
@@ -1,7 +1,13 @@
+import { RootState } from "../store"
 import { FMSId, FMSTrackedModel } from "./fms_api_models"
 import { ItemsByID } from "./frontend_models"
 
 // Models for paged items, used in redux to hold lists of objects
+
+export interface FilterOption {
+	label: string
+	value: string
+}
 
 export interface FilterDescription {
 	type: string
@@ -11,7 +17,8 @@ export interface FilterDescription {
 	recursive?: boolean
 	batch?: boolean
 	placeholder?: string
-	options?: { label: string; value: string }[]
+	options?: FilterOption[]
+	dynamicOptions?: () => FilterOption[]	// A function that generates options when the filter is initialized.
 	width?: number
 	detached?: boolean
 	defaultMin?: number

--- a/frontend/src/modules/labwork/actions.ts
+++ b/frontend/src/modules/labwork/actions.ts
@@ -1,4 +1,4 @@
-import { selectLabworkSummaryState, selectProtocolsByID, selectWorkflowsByID } from '../../selectors'
+import { selectLabworkSummaryState, selectWorkflowsByID } from '../../selectors'
 import { createNetworkActionTypes } from '../../utils/actions'
 import api from '../../utils/api'
 import { refreshSamplesAtStep } from '../labworkSteps/actions'

--- a/frontend/src/modules/labworkSteps/reducers.ts
+++ b/frontend/src/modules/labworkSteps/reducers.ts
@@ -3,7 +3,7 @@ import { clearFiltersReducer, setFilterOptionsReducer, setFilterReducer } from '
 import { FMSId } from '../../models/fms_api_models'
 import { createItemsByID, SampleNextStep } from '../../models/frontend_models'
 import { templateActionsReducerFactory } from '../../utils/templateActions'
-import { CLEAR_FILTERS, CLEAR_SELECTION_CHANGED_MESSAGE, FLUSH_SAMPLES_AT_STEP, INIT_SAMPLES_AT_STEP, LIST, LIST_TEMPLATE_ACTIONS, SET_FILTER, SET_FILTER_OPTION, SET_SELECTED_SAMPLES, SET_SORT_BY, SHOW_SELECTION_CHANGED_MESSAGE } from './actions'
+import { CLEAR_FILTERS, FLUSH_SAMPLES_AT_STEP, INIT_SAMPLES_AT_STEP, LIST, LIST_TEMPLATE_ACTIONS, SET_FILTER, SET_FILTER_OPTION, SET_SELECTED_SAMPLES, SET_SORT_BY, SHOW_SELECTION_CHANGED_MESSAGE } from './actions'
 import { LabworkStepSamples, LabworkStepsState } from './models'
 
 const INTIAL_STATE: LabworkStepsState = {


### PR DESCRIPTION
The sample KIND column filter needs to be initialized from the sample kinds contained in the redux store - we have to generate a list of options for the Select element. This change adds the ability to define a function to generate the options dynamically.

It also cleans up some excessive rendering in the LabworkStep component by making proper use of `useCallback` and `useMemo`.

Finally, I fixed a bug in the filter serializer for SELECT values.