### PR TITLE
Download static templates in dev

### DIFF
--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -76,6 +76,9 @@ module.exports = (env, argv) => ({
       "/api": {
         target: "http://localhost:8000",
       },
+       "/static/submission_templates": {
+        target: "http://localhost:8000"
+      }
     },
   },
 });


### PR DESCRIPTION
Make templates downloadable in dev. Just needed to add an extra proxy setting in the webpack config file.