### PR TITLE
Bugfix: duplicate Project columns

### DIFF
--- a/frontend/src/components/shared/WorkflowSamplesTable/ColumnSets.ts
+++ b/frontend/src/components/shared/WorkflowSamplesTable/ColumnSets.ts
@@ -19,7 +19,6 @@ export function getColumnsForStep(step: Step, protocol: Protocol): IdentifiedTab
 
 	const DEFAULT_SAMPLE_COLUMNS = [
 		SAMPLE_COLUMNS.ID,
-		SAMPLE_COLUMNS.PROJECT,
 		SAMPLE_COLUMNS.KIND,
 		SAMPLE_COLUMNS.NAME,
 		SAMPLE_COLUMNS.PROJECT,
@@ -34,7 +33,6 @@ export function getColumnsForStep(step: Step, protocol: Protocol): IdentifiedTab
 
 	const PRE_QC_SAMPLE_COLUMNS = [
 		SAMPLE_COLUMNS.ID,
-		SAMPLE_COLUMNS.PROJECT,
 		SAMPLE_COLUMNS.KIND,
 		SAMPLE_COLUMNS.NAME,
 		SAMPLE_COLUMNS.PROJECT,
@@ -48,7 +46,6 @@ export function getColumnsForStep(step: Step, protocol: Protocol): IdentifiedTab
 
 	const DEFAULT_LIBRARY_COLUMNS = [
 		SAMPLE_COLUMNS.ID,
-		SAMPLE_COLUMNS.PROJECT,
 		LIBRARY_COLUMNS.LIBRARY_TYPE,
 		SAMPLE_COLUMNS.NAME,
 		SAMPLE_COLUMNS.PROJECT,
@@ -65,7 +62,6 @@ export function getColumnsForStep(step: Step, protocol: Protocol): IdentifiedTab
 
 	const PRE_QC_LIBRARY_COLUMNS = [
 		SAMPLE_COLUMNS.ID,
-		SAMPLE_COLUMNS.PROJECT,
 		LIBRARY_COLUMNS.LIBRARY_TYPE,
 		SAMPLE_COLUMNS.NAME,
 		SAMPLE_COLUMNS.PROJECT,
@@ -79,7 +75,6 @@ export function getColumnsForStep(step: Step, protocol: Protocol): IdentifiedTab
 
 	const EXPERIMENT_COLUMNS = [
 		SAMPLE_COLUMNS.ID,
-		SAMPLE_COLUMNS.PROJECT,
 		SAMPLE_COLUMNS.NAME,
 		SAMPLE_COLUMNS.PROJECT,
 		SAMPLE_COLUMNS.CONTAINER_BARCODE,


### PR DESCRIPTION
A merge error resulted in the Project column appearing twice in labwork samples tables.