### PR TITLE
Fix unique key errors in list pages

### DIFF
--- a/frontend/src/components/containers/ContainersListContent.js
+++ b/frontend/src/components/containers/ContainersListContent.js
@@ -11,8 +11,8 @@ import ExportButton from "../ExportButton";
 
 import {listTable, setFilter, setFilterOption, clearFilters, setSortBy} from "../../modules/containers/actions";
 import api, {withToken}  from "../../utils/api"
-import {actionDropdown} from "../../utils/templateActions";
-import {prefillTemplatesToButtonDropdown} from "../../utils/prefillTemplates";
+import {ActionDropdown} from "../../utils/templateActions";
+import {PrefilledTemplatesDropdown} from "../../utils/prefillTemplates";
 import {withContainer, withSample, withCoordinate} from "../../utils/withItem";
 import mergedListQueryParams from "../../utils/mergedListQueryParams";
 
@@ -155,8 +155,8 @@ const ContainersListContent = ({
   return <>
     <AppPageHeader title="Containers" extra={[
       <AddButton key='add' url="/containers/add" />,
-      actionDropdown("/containers", actions),
-      prefillTemplatesToButtonDropdown(prefillTemplate, totalCount, prefills),
+      <ActionDropdown key='actions' urlBase={"/containers"} actions={actions}/>,
+      <PrefilledTemplatesDropdown key='prefills' prefillTemplate={prefillTemplate} totalCount={totalCount} prefills={prefills}/>,
       <ExportButton key='export' exportFunction={listExport} filename="containers" itemsCount={totalCount}/>,
     ]}/>
     <PageContent>

--- a/frontend/src/components/experimentRuns/ExperimentRunsListContent.js
+++ b/frontend/src/components/experimentRuns/ExperimentRunsListContent.js
@@ -16,7 +16,7 @@ import getNFilters from "../filters/getNFilters";
 import FiltersWarning from "../filters/FiltersWarning";
 import mergedListQueryParams from "../../utils/mergedListQueryParams";
 import {withContainer} from "../../utils/withItem";
-import {actionDropdown} from "../../utils/templateActions";
+import {ActionDropdown} from "../../utils/templateActions";
 import ExperimentRunLaunchCard from "./ExperimentRunLaunchCard"
 
 
@@ -142,7 +142,7 @@ const ExperimentRunsListContent = ({
 
   return <>
     <AppPageHeader title="Experiments" extra={[
-        actionDropdown("/experiment-runs", actions),
+        <ActionDropdown key='actions' urlBase={"/experiment-runs"} actions={actions}/>,
         <ExportButton key='export' exportFunction={listExport} filename="experiments"  itemsCount={totalCount}/>,
     ]}/>
     <PageContent>

--- a/frontend/src/components/indices/IndicesListContent.js
+++ b/frontend/src/components/indices/IndicesListContent.js
@@ -16,7 +16,7 @@ import api, {withToken}  from "../../utils/api"
 import {withSequence} from "../../utils/withItem";
 
 import {listTable, setFilter, setFilterOption, clearFilters, setSortBy} from "../../modules/indices/actions";
-import {actionDropdown} from "../../utils/templateActions";
+import {ActionDropdown} from "../../utils/templateActions";
 import {INDEX_FILTERS} from "../filters/descriptions";
 import getFilterProps from "../filters/getFilterProps";
 import getNFilters from "../filters/getNFilters";
@@ -133,10 +133,10 @@ const IndicesListContent = ({
 
   return <>
     <AppPageHeader title="Indices" extra={[
-      <Button onClick={() => history("/indices/validate")}>
+      <Button key='validate' onClick={() => history("/indices/validate")}>
         <CheckOutlined /> Validate Indices
       </Button>,
-      actionDropdown("/indices", actions),
+      <ActionDropdown key='actions' urlBase={"/indices"} actions={actions}/>,
       <ExportButton key='export' exportFunction={listExport} filename="indices" itemsCount={totalCount}/>,
     ]}/>
     <PageContent>

--- a/frontend/src/components/libraries/LibrariesListContent.js
+++ b/frontend/src/components/libraries/LibrariesListContent.js
@@ -1,7 +1,7 @@
-import React, {useRef, useState, useEffect} from "react";
+import React, {useState, useEffect} from "react";
 import {connect} from "react-redux";
 import {Link} from "react-router-dom";
-import {Button, Tag, Radio} from "antd";
+import {Button, Radio} from "antd";
 
 import AppPageHeader from "../AppPageHeader";
 import PageContent from "../PageContent";
@@ -13,8 +13,8 @@ import ExportButton from "../ExportButton";
 import api, {withToken}  from "../../utils/api"
 
 import {listTable, setFilter, setFilterOption, clearFilters, setSortBy, clearSortBy} from "../../modules/libraries/actions";
-import {actionDropdown} from "../../utils/templateActions";
-import {prefillTemplatesToButtonDropdown} from "../../utils/prefillTemplates";
+import {ActionDropdown} from "../../utils/templateActions";
+import {PrefilledTemplatesDropdown} from "../../utils/prefillTemplates";
 import {withContainer, withCoordinate, withIndex} from "../../utils/withItem";
 import {LIBRARY_FILTERS} from "../filters/descriptions";
 import getFilterProps from "../filters/getFilterProps";
@@ -284,8 +284,8 @@ const LibrariesListContent = ({
 
   return <>
     <AppPageHeader title="Libraries" extra={[
-      actionDropdown("/libraries", actions),
-      prefillTemplatesToButtonDropdown(prefillTemplate, totalCount, prefills),
+      <ActionDropdown key='actions' urlBase={"/libraries"} actions={actions}/>,
+      <PrefilledTemplatesDropdown key='prefills' prefillTemplate={prefillTemplate} totalCount={totalCount} prefills={prefills}/>,
       <ExportButton key='export' exportFunction={listExport} filename="libraries" itemsCount={totalCount}/>,
     ]}/>
     <PageContent>

--- a/frontend/src/components/processMeasurements/ProcessMeasurementsListContent.js
+++ b/frontend/src/components/processMeasurements/ProcessMeasurementsListContent.js
@@ -11,7 +11,7 @@ import ExportButton from "../ExportButton";
 import api, {withToken}  from "../../utils/api"
 
 import {listTable, setFilter, setFilterOption, clearFilters, setSortBy} from "../../modules/processMeasurements/actions";
-import {actionDropdown} from "../../utils/templateActions";
+import {ActionDropdown} from "../../utils/templateActions";
 import {withSample} from "../../utils/withItem";
 import mergedListQueryParams from "../../utils/mergedListQueryParams";
 import {PROCESS_MEASUREMENT_FILTERS} from "../filters/descriptions";
@@ -140,7 +140,7 @@ const ProcessMeasurementsListContent = ({
 
   return <>
     <AppPageHeader title="Protocols" extra={[
-      actionDropdown("/process-measurements", actions),
+      <ActionDropdown key='actions' urlBase={"/process-measurements"} actions={actions}/>,
       <ExportButton key='export' exportFunction={listExport} filename="processes"  itemsCount={totalCount}/>,
     ]}/>
     <PageContent>

--- a/frontend/src/components/projects/ProjectsListContent.js
+++ b/frontend/src/components/projects/ProjectsListContent.js
@@ -13,7 +13,7 @@ import api, { withToken } from "../../utils/api";
 
 import { clearFilters, listTable, setFilter, setFilterOption, setSortBy } from "../../modules/projects/actions";
 import mergedListQueryParams from "../../utils/mergedListQueryParams";
-import { actionDropdown } from "../../utils/templateActions";
+import { ActionDropdown } from "../../utils/templateActions";
 import { PROJECT_FILTERS } from "../filters/descriptions";
 import FiltersWarning from "../filters/FiltersWarning";
 import getFilterProps from "../filters/getFilterProps";
@@ -121,7 +121,7 @@ const ProjectsListContent = ({
   return <>
     <AppPageHeader title="Projects" extra={[
       <AddButton key='add' url="/projects/add" />,
-      actionDropdown("/projects", actions),
+      <ActionDropdown key='actions' urlBase={'/projects'} actions={actions}/>,
       <ExportButton key='export' exportFunction={listExport} filename="projects" itemsCount={totalCount}/>,
     ]}/>
     <PageContent>

--- a/frontend/src/components/samples/SamplesListContent.js
+++ b/frontend/src/components/samples/SamplesListContent.js
@@ -1,30 +1,29 @@
-import React, {useRef, useState, useEffect} from "react";
-import {connect} from "react-redux";
-import {Link} from "react-router-dom";
-import {Button, Tag, Radio} from "antd";
+import { Button, Radio, Tag } from "antd";
+import React, { useEffect, useState } from "react";
+import { connect } from "react-redux";
+import { Link } from "react-router-dom";
 
+import AddButton from "../AddButton";
 import AppPageHeader from "../AppPageHeader";
+import { Depletion } from "../Depletion";
+import ExportDropdown from "../ExportDropdown";
 import PageContent from "../PageContent";
 import PaginatedTable from "../PaginatedTable";
-import {Depletion} from "../Depletion";
-import {QCFlag} from "../QCFlag";
-import AddButton from "../AddButton";
-import ExportButton from "../ExportButton";
-import ExportDropdown from "../ExportDropdown"
+import { QCFlag } from "../QCFlag";
 
-import api, {withToken}  from "../../utils/api"
+import api, { withToken } from "../../utils/api";
 
-import {listTable, setFilter, setFilterOption, clearFilters, setSortBy, clearSortBy} from "../../modules/samples/actions";
-import {actionDropdown} from "../../utils/templateActions";
-import {prefillTemplatesToButtonDropdown} from "../../utils/prefillTemplates";
-import {withContainer, withCoordinate, withIndividual, withProject} from "../../utils/withItem";
-import {SAMPLE_FILTERS} from "../filters/descriptions";
+import { TOGGLE_OPTIONS } from "../../constants.js";
+import { clearFilters, clearSortBy, listTable, setFilter, setFilterOption, setSortBy } from "../../modules/samples/actions";
+import mergedListQueryParams from "../../utils/mergedListQueryParams";
+import { PrefilledTemplatesDropdown } from "../../utils/prefillTemplates";
+import { ActionDropdown } from "../../utils/templateActions";
+import { withContainer, withCoordinate, withIndividual, withProject } from "../../utils/withItem";
+import FiltersWarning from "../filters/FiltersWarning";
+import { SAMPLE_FILTERS } from "../filters/descriptions";
 import getFilterProps from "../filters/getFilterProps";
 import getNFilters from "../filters/getNFilters";
-import FiltersWarning from "../filters/FiltersWarning";
 import SamplesFilters from "./SamplesFilters";
-import mergedListQueryParams from "../../utils/mergedListQueryParams";
-import {TOGGLE_OPTIONS} from "../../constants.js"
 
 const getTableColumns = (containersByID, individualsByID, projectsByID, coordinatesByID, sampleKinds, toggleOption) => [
     {
@@ -263,8 +262,8 @@ const SamplesListContent = ({
   return <>
     <AppPageHeader title="Samples" extra={[
       <AddButton key='add' url="/samples/add" />,
-      actionDropdown("/samples", actions),
-      prefillTemplatesToButtonDropdown(prefillTemplate, totalCount, prefills),
+      <ActionDropdown key='actions' urlBase={"/samples"} actions={actions}/>,
+      <PrefilledTemplatesDropdown key='prefills' prefillTemplate={prefillTemplate} totalCount={totalCount} prefills={prefills}/>,
       <ExportDropdown key='export' listExport={listExport} listExportMetadata={listExportMetadata} itemsCount={totalCount}/>,
     ]}/>
     <PageContent>

--- a/frontend/src/utils/prefillTemplates.js
+++ b/frontend/src/utils/prefillTemplates.js
@@ -29,7 +29,7 @@ export function PrefilledTemplatesDropdown({prefillTemplate, totalCount, prefill
       { prefills && prefills.items && prefills.items.map((prefill) =>
           <Menu.Item key={prefill.id.toString()}>
             <PrefillTemplateButton
-              style={{border:0}}
+              style={{width:'100%', border:0, textAlign: 'left'}}
               key='export'
               exportFunction={prefillTemplate}
               filename={prefill.description}

--- a/frontend/src/utils/prefillTemplates.js
+++ b/frontend/src/utils/prefillTemplates.js
@@ -23,7 +23,7 @@ export const templateIcon = t => {
   return undefined;
 };
 
-export const prefillTemplatesToButtonDropdown = (prefillTemplate, totalCount, prefills) => {
+export function PrefilledTemplatesDropdown({prefillTemplate, totalCount, prefills}) {
   const prefillChoiceMenu = (
     <Menu>
       { prefills && prefills.items && prefills.items.map((prefill) =>

--- a/frontend/src/utils/templateActions.js
+++ b/frontend/src/utils/templateActions.js
@@ -32,7 +32,7 @@ export const actionsToButtonList = (urlBase, actions, fullWidth=false) =>
     </Link>
   );
 
-export function ActionDropdown({urlBase, actions, fullWidth = false}) {
+export function ActionDropdown({urlBase, actions, fullWidth = true}) {
   const history = useNavigate();
   const actionMenu = (
     <Menu>
@@ -41,7 +41,7 @@ export function ActionDropdown({urlBase, actions, fullWidth = false}) {
             <Button
               icon={actionIcon(a)}
               onClick={() => history(`${urlBase}/actions/${a.id}/`)}
-              {...(fullWidth ? {style:{width:"100%", border:0}} : {style:{border:0}})}
+              {...(fullWidth ? {style:{width:"100%", border:0, textAlign:'left'}} : {style:{border:0}})}
             >
               {a.name}
             </Button>

--- a/frontend/src/utils/templateActions.js
+++ b/frontend/src/utils/templateActions.js
@@ -32,7 +32,7 @@ export const actionsToButtonList = (urlBase, actions, fullWidth=false) =>
     </Link>
   );
 
-export const actionDropdown = (urlBase, actions, fullWidth=false) => {
+export function ActionDropdown({urlBase, actions, fullWidth = false}) {
   const history = useNavigate();
   const actionMenu = (
     <Menu>
@@ -56,7 +56,7 @@ export const actionDropdown = (urlBase, actions, fullWidth=false) => {
               <MonitorOutlined />  Available Actions
             </Button>
           </Dropdown>)
-};
+}
 
 export const templateActionsReducerFactory = moduleActions => (
   state = {


### PR DESCRIPTION
Fixes a react 'unique key' error in  pages that include the actions dropdown and prefilled templates dropdown. This is to reduce noise in the console.

I converted the functions that generate these dropdowns to proper React components so that I could assign a key to the dropdown elements where they are used in page headers.

~~There shouldn't be any change in the existing behaviour of the dropdowns.~~

The template actions and prefilled template menu were tweaked so that menu item buttons span the entire width of the menu (except for ant padding).