### PR TITLE
Feature #1635: Add a way to visually identify QC and DEV instance

### DIFF
--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -153,6 +153,8 @@ const MENU_ITEMS = [
   },
 ]
 
+const notProdBanner = "repeating-linear-gradient(45deg, #696104, #696104 10px, #000000 10px, #000000 20px)";
+
 const colorStyle = {
   color: "white",
 }
@@ -164,6 +166,7 @@ const titleStyle = {
   lineHeight: "unset",
   padding: 0,
   margin: 0,
+  textAlign: 'center'
 };
 
 export const mapStateToProps = state => ({
@@ -174,6 +177,7 @@ export const mapStateToProps = state => ({
 export const actionCreators = {logOut, get};
 
 const App = ({userID, usersByID, logOut, get}) => {
+  const env = FMS_ENV
 
   const dispatch = useAppDispatch()
   const isInitialized = useAppSelector(selectAppInitialzed)
@@ -228,15 +232,15 @@ const App = ({userID, usersByID, logOut, get}) => {
             width={'17em'} 
             style={{overflow: 'auto'}}
           >
-            <div style={{display: 'flex', alignContent: 'baseline', justifyContent: 'left', textAlign: 'center'}}>
+            <div style={{alignContent: 'baseline', justifyContent: 'left', textAlign: 'center', background: env !== 'PROD' ? notProdBanner : undefined}}>
               <Title style={titleStyle} className="App__title">
                 <div>
-                  <b>F</b><span>reeze</span><b>M</b><span>an</span>
+                  <span>FreezeMan</span>{env !== 'PROD' && <span style={{color: 'red'}}>&nbsp;{env}</span>}
                 </div>
               </Title>
               { // Display a spinner while the initial data is being fetched at startup 
                 !isInitialized &&
-                  <div style={{display: 'flex', flexDirection: 'column', justifyContent: 'center'}}>
+                  <div style={{position: 'absolute', left: '0', right: '0', top: env !== 'PROD' ? '3.25rem' : '3.5rem'}}>
                     <Spin size="small" indicator={loadingIcon}/>
                   </div>
               }

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -153,7 +153,7 @@ const MENU_ITEMS = [
   },
 ]
 
-const notProdBanner = "repeating-linear-gradient(45deg, #696104, #696104 10px, #000000 10px, #000000 20px)";
+const DEV_QC_BACKGROUND = "repeating-linear-gradient(45deg, #696104, #696104 10px, #000000 10px, #000000 20px)";
 
 const colorStyle = {
   color: "white",
@@ -234,7 +234,7 @@ const App = ({userID, usersByID, logOut, get}) => {
             width={'17em'} 
             style={{overflow: 'auto'}}
           >
-            <div style={{alignContent: 'baseline', textAlign: 'center', background: env !== 'PROD' ? notProdBanner : undefined}}>
+            <div style={{alignContent: 'baseline', textAlign: 'center', background: env !== 'PROD' ? DEV_QC_BACKGROUND : undefined}}>
               <Title style={titleStyle} className="App__title">
                 <b>F</b><span>reeze</span><b>M</b><span>an</span>
                 {env !== 'PROD' && <span style={{ color: 'red' }}>&nbsp;{env}</span>}
@@ -243,7 +243,7 @@ const App = ({userID, usersByID, logOut, get}) => {
               <Spin
                 size="small"
                 indicator={loadingIcon}
-                style={{ visibility: !isInitialized ? undefined : 'hidden', paddingBottom: '0.2rem' }}
+                style={{ visibility: isInitialized ? 'hidden' : undefined, paddingBottom: '0.2rem' }}
               />
             </div>
 

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -153,7 +153,7 @@ const MENU_ITEMS = [
   },
 ]
 
-const DEV_QC_BACKGROUND = "repeating-linear-gradient(45deg, #696104, #696104 10px, #000000 10px, #000000 20px)";
+const DEV_QC_BACKGROUND = "repeating-linear-gradient(45deg, #423d01, #423d01 10px, #000000 10px, #000000 20px)";
 
 const colorStyle = {
   color: "white",
@@ -166,8 +166,6 @@ const titleStyle = {
   lineHeight: "unset",
   padding: 0,
   margin: 0,
-  textAlign: 'center',
-  paddingTop: '1.5rem'
 };
 
 export const mapStateToProps = state => ({
@@ -234,19 +232,22 @@ const App = ({userID, usersByID, logOut, get}) => {
             width={'17em'} 
             style={{overflow: 'auto'}}
           >
-            <div style={{alignContent: 'baseline', textAlign: 'center', background: env !== 'PROD' ? DEV_QC_BACKGROUND : undefined}}>
-              <Title style={titleStyle} className="App__title">
-                <b>F</b><span>reeze</span><b>M</b><span>an</span>
-                {env !== 'PROD' && <span style={{ color: 'red' }}>&nbsp;{env}</span>}
-              </Title>
-              {/* Display a spinner while the initial data is being fetched at startup */}
-              <Spin
-                size="small"
-                indicator={loadingIcon}
-                style={{ visibility: isInitialized ? 'hidden' : undefined, paddingBottom: '0.2rem' }}
-              />
+            <div style={{background: env !== 'PROD' ? DEV_QC_BACKGROUND : undefined, padding: 0, margin: 0}}>
+              <div style={{display: 'flex', alignContent: 'baseline', justifyContent: 'left', textAlign: 'center'}}>
+                <Title style={titleStyle} className="App__title">
+                  <div style={{marginRight: '0.25rem', paddingRight: '0.25rem'}}>
+                    <b>F</b><span>reeze</span><b>M</b><span>an</span>
+                    {env !== 'PROD' && <span style={{ color: 'red', fontSize: '14px' }}>&nbsp;{env}</span>}
+                  </div>
+                </Title>
+                { // Display a spinner while the initial data is being fetched at startup 
+                  !isInitialized &&
+                    <div style={{display: 'flex', flexDirection: 'column', justifyContent: 'center'}}>
+                      <Spin size="small" indicator={loadingIcon}/>
+                    </div>
+                }
+              </div>
             </div>
-
             {isLoggedIn &&
                 <div className='App__jumpBar'>
                   <JumpBar />

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -236,7 +236,7 @@ const App = ({userID, usersByID, logOut, get}) => {
           >
             <div style={{alignContent: 'baseline', textAlign: 'center', background: env !== 'PROD' ? notProdBanner : undefined}}>
               <Title style={titleStyle} className="App__title">
-                <span>FreezeMan</span>
+                <b>F</b><span>reeze</span><b>M</b><span>an</span>
                 {env !== 'PROD' && <span style={{ color: 'red' }}>&nbsp;{env}</span>}
               </Title>
               {/* Display a spinner while the initial data is being fetched at startup */}

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -34,7 +34,7 @@ import useUserInputExpiration from "../utils/useUserInputExpiration";
 import { useAppDispatch, useAppSelector } from "../hooks";
 import { setAppInitialized } from "../modules/app/actions";
 import { logOut } from "../modules/auth/actions";
-import { fetchInitialData, fetchSummariesData, fetchStaticData, fetchLabworkSummary, fetchListedData } from "../modules/shared/actions";
+import { fetchSummariesData, fetchStaticData, fetchLabworkSummary, fetchListedData } from "../modules/shared/actions";
 import { get } from "../modules/users/actions";
 import { selectAppInitialzed, selectAuthTokenAccess, } from "../selectors";
 import DatasetsPage from "./datasets/DatasetsPage";
@@ -166,7 +166,8 @@ const titleStyle = {
   lineHeight: "unset",
   padding: 0,
   margin: 0,
-  textAlign: 'center'
+  textAlign: 'center',
+  paddingTop: '1.5rem'
 };
 
 export const mapStateToProps = state => ({
@@ -177,6 +178,7 @@ export const mapStateToProps = state => ({
 export const actionCreators = {logOut, get};
 
 const App = ({userID, usersByID, logOut, get}) => {
+  /* global FMS_ENV */
   const env = FMS_ENV
 
   const dispatch = useAppDispatch()
@@ -200,7 +202,7 @@ const App = ({userID, usersByID, logOut, get}) => {
     }, 30000);
 
     return () => clearInterval(interval);
-  }, [token]);
+  }, [dispatch, token]);
 
   const isLoggedIn = userID !== null;
   const user = usersByID[userID];
@@ -243,7 +245,7 @@ const App = ({userID, usersByID, logOut, get}) => {
                 indicator={loadingIcon}
                 style={{ visibility: !isInitialized ? undefined : 'hidden', paddingBottom: '0.2rem' }}
               />
-                  </div>
+            </div>
 
             {isLoggedIn &&
                 <div className='App__jumpBar'>
@@ -385,6 +387,7 @@ function onDidMount() {
 }
 
 function withRouter(Child) {
+  // eslint-disable-next-line react/display-name
   return (props) => {
     const location = useLocation();
     const navigate = useNavigate();

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -242,7 +242,7 @@ const App = ({userID, usersByID, logOut, get}) => {
                 </Title>
                 { // Display a spinner while the initial data is being fetched at startup 
                   !isInitialized &&
-                    <div style={{display: 'flex', flexDirection: 'column', justifyContent: 'center'}}>
+                    <div style={{display: 'flex', flexDirection: 'column', justifyContent: 'center'}} className="App__spin">
                       <Spin size="small" indicator={loadingIcon}/>
                     </div>
                 }

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -232,19 +232,19 @@ const App = ({userID, usersByID, logOut, get}) => {
             width={'17em'} 
             style={{overflow: 'auto'}}
           >
-            <div style={{alignContent: 'baseline', justifyContent: 'left', textAlign: 'center', background: env !== 'PROD' ? notProdBanner : undefined}}>
+            <div style={{alignContent: 'baseline', textAlign: 'center', background: env !== 'PROD' ? notProdBanner : undefined}}>
               <Title style={titleStyle} className="App__title">
-                <div>
-                  <span>FreezeMan</span>{env !== 'PROD' && <span style={{color: 'red'}}>&nbsp;{env}</span>}
-                </div>
+                <span>FreezeMan</span>
+                {env !== 'PROD' && <span style={{ color: 'red' }}>&nbsp;{env}</span>}
               </Title>
-              { // Display a spinner while the initial data is being fetched at startup 
-                !isInitialized &&
-                  <div style={{position: 'absolute', left: '0', right: '0', top: env !== 'PROD' ? '3.25rem' : '3.5rem'}}>
-                    <Spin size="small" indicator={loadingIcon}/>
+              {/* Display a spinner while the initial data is being fetched at startup */}
+              <Spin
+                size="small"
+                indicator={loadingIcon}
+                style={{ visibility: !isInitialized ? undefined : 'hidden', paddingBottom: '0.2rem' }}
+              />
                   </div>
-              }
-            </div>
+
             {isLoggedIn &&
                 <div className='App__jumpBar'>
                   <JumpBar />

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -115,3 +115,7 @@ abbr.--time {
   align-items: baseline;
 }
 
+.ant-layout-sider-collapsed .App__spin {
+  width: 0 !important;
+  opacity: 0;
+}

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -62,7 +62,7 @@ module.exports = (env, argv) => ({
       GIT_BRANCH: JSON.stringify(gitRevisionPlugin.branch()),
       GIT_LASTUPDATE: JSON.stringify(child_process.execSync('git log -1 --format=%cI').toString().trim()),
       FMS_VERSION: JSON.stringify(fs.readFileSync('../backend/VERSION', 'utf8')),
-      FMS_ENV: JSON.stringify(process.env.FMS_ENV || "LOCAL")
+      FMS_ENV: JSON.stringify(process.env.FMS_ENV || "DEV")
     }),
   ],
 

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -62,7 +62,7 @@ module.exports = (env, argv) => ({
       GIT_BRANCH: JSON.stringify(gitRevisionPlugin.branch()),
       GIT_LASTUPDATE: JSON.stringify(child_process.execSync('git log -1 --format=%cI').toString().trim()),
       FMS_VERSION: JSON.stringify(fs.readFileSync('../backend/VERSION', 'utf8')),
-      FMS_ENV: JSON.stringify(process.env.FMS_ENV || "DEV")
+      FMS_ENV: JSON.stringify(process.env.FMS_ENV || "LOCAL")
     }),
   ],
 


### PR DESCRIPTION
https://206.12.92.46/issues/1635

- Add QC or LOCAL next to Freezeman name in the left bar in order to identify the instance.
- Use black-yellow zebra pattern to identify further

LOCAL:
![image](https://user-images.githubusercontent.com/15523177/236245406-55f1ee8b-e605-4379-b2b1-2e3dbb9ae752.png)

QC:
![image](https://user-images.githubusercontent.com/15523177/236245559-45dfd4c8-9606-4fb0-808b-1685a571c9bb.png)

PROD:
![image](https://user-images.githubusercontent.com/15523177/236246608-8514a8d1-d13d-4261-9512-df25edd46f2b.png)
