### PR TITLE
Widen sidebar for Reference Genomes

### DIFF
--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -223,7 +223,9 @@ const App = ({userID, usersByID, logOut, get}) => {
             className="App__sidebar"
             breakpoint="md"
             collapsedWidth={80}
-            width={224}
+             // Ant requires a width, so pick one relative to the sidebar font-size. You can use 'auto' but then
+            // the sidebar width changes whenever a submenu is expanded or collapsed.
+            width={'17em'} 
             style={{overflow: 'auto'}}
           >
             <div style={{display: 'flex', alignContent: 'baseline', justifyContent: 'left', textAlign: 'center'}}>


### PR DESCRIPTION
Increase the sidebar width to fit "Reference Genomes". The width is set to 17em, to make the sidebar width relative to the font size. 

Ideally we would set the width to 'auto' but that causes the sidebar width to change whenever the "Definitions" section is expanded or collapsed - it jumps around. :(