### PR TITLE
Return distinct pools from sample-next-step endpoints

### DIFF
--- a/backend/fms_core/viewsets/sample_next_step.py
+++ b/backend/fms_core/viewsets/sample_next_step.py
@@ -19,7 +19,7 @@ from fms_core.template_importer.importers import (ExtractionImporter, SampleQCIm
                                                   LibraryConversionImporter, ExperimentRunImporter)
 
 class SampleNextStepViewSet(viewsets.ModelViewSet, TemplateActionsMixin, TemplatePrefillsLabWorkMixin):
-    queryset = SampleNextStep.objects.all()
+    queryset = SampleNextStep.objects.all().distinct()
     serializer_class = SampleNextStepSerializer
     permission_classes = [IsAuthenticated]
 

--- a/backend/fms_core/viewsets/sample_next_step_by_study.py
+++ b/backend/fms_core/viewsets/sample_next_step_by_study.py
@@ -16,7 +16,7 @@ from fms_core.serializers import SampleNextStepByStudySerializer
 from ._utils import _list_keys
 
 class SampleNextStepByStudyViewSet(viewsets.ModelViewSet):
-    queryset = SampleNextStepByStudy.objects.select_related("sample_next_step").select_related("step_order").all()
+    queryset = SampleNextStepByStudy.objects.select_related("sample_next_step").select_related("step_order").all().distinct()
     serializer_class = SampleNextStepByStudySerializer
     permission_classes = [IsAuthenticated]
 

--- a/frontend/src/components/shared/WorkflowSamplesTable/ColumnSets.ts
+++ b/frontend/src/components/shared/WorkflowSamplesTable/ColumnSets.ts
@@ -8,6 +8,8 @@ export interface SampleAndLibrary extends ObjectWithSample, ObjectWithLibrary {}
 
 
 export function getColumnsForStudySamplesStep(step: Step, protocol: Protocol) {
+	// A study is associated with a single project, so it doesn't make sense to include
+	// a project column in study sample tables, so we filter it out.
 	return getColumnsForStep(step, protocol).filter(column => column.columnID !== SampleColumnID.PROJECT)
 }
 

--- a/frontend/src/components/shared/WorkflowSamplesTable/MergeColumnsAndFilters.ts
+++ b/frontend/src/components/shared/WorkflowSamplesTable/MergeColumnsAndFilters.ts
@@ -55,7 +55,11 @@ export function addFiltersToColumns<T>(
 			return {
 				...column,
 				...props,
-				sorter: addSorter,
+				// Only set sorter if it is not already defined in the column definition, 
+				// so that components can override this default behaviour. A component can set a value
+				// in the column definition to force sorter to be true or false, or leave it undefined
+				// to get the default behaviour.
+				sorter: column.sorter === undefined ? addSorter : column.sorter,
 				key			// Column key needs to be set for sortBy functionality
 			}
 		}

--- a/frontend/src/components/shared/WorkflowSamplesTable/SampleTableColumns.tsx
+++ b/frontend/src/components/shared/WorkflowSamplesTable/SampleTableColumns.tsx
@@ -207,6 +207,7 @@ export const SAMPLE_COLUMN_DEFINITIONS: { [key in SampleColumnID]: SampleColumn 
 		columnID: SampleColumnID.PROJECT,
 		title: 'Project',
 		dataIndex: ['sample', 'project'],
+		sorter: false,	// Disable project sorting, due to pools not being sortable by project
 		render: (projectID) => 
 			projectID && (
 				<WithProjectRenderComponent 

--- a/frontend/src/components/studySamples/StudyStepSamplesTable.tsx
+++ b/frontend/src/components/studySamples/StudyStepSamplesTable.tsx
@@ -5,7 +5,7 @@ import { Protocol } from '../../models/frontend_models'
 import { clearFilters, setStudyStepFilter, setStudyStepFilterOptions, setStudyStepSortOrder } from '../../modules/studySamples/actions'
 import { StudySampleStep, StudyUXStepSettings } from '../../modules/studySamples/models'
 import { selectProtocolsByID, selectStepsByID } from '../../selectors'
-import { SampleAndLibrary, getColumnsForStep } from '../shared/WorkflowSamplesTable/ColumnSets'
+import { SampleAndLibrary, getColumnsForStep, getColumnsForStudySamplesStep } from '../shared/WorkflowSamplesTable/ColumnSets'
 import { LIBRARY_COLUMN_FILTERS, SAMPLE_NEXT_STEP_BY_STUDY_LIBRARY_FILTER_KEYS } from '../shared/WorkflowSamplesTable/LibraryTableColumns'
 import { IdentifiedTableColumnType, SAMPLE_COLUMN_FILTERS, SAMPLE_NEXT_STEP_BY_STUDY_FILTER_KEYS, SampleColumnID } from '../shared/WorkflowSamplesTable/SampleTableColumns'
 import WorkflowSamplesTable from '../shared/WorkflowSamplesTable/WorkflowSamplesTable'
@@ -49,7 +49,7 @@ function StudyStepSamplesTable({ studyID, step, settings }: StudyStepSamplesTabl
 		if (protocol && stepDefinition) {
 			// Same columns as labwork, but we don't want the Project column, since the user
 			// is already in the project details page.
-			return getColumnsForStep(stepDefinition, protocol).filter(col => col.columnID !== SampleColumnID.PROJECT)
+			return getColumnsForStudySamplesStep(stepDefinition, protocol)
 		} else {
 			return []
 		}


### PR DESCRIPTION
The sample-next-step and sample-next-by-study endpoints would return multiple instances of the same pool if the user filters by project name. This PR fixes that. It also disables sorting on the project column, because that also results in multiple instances of the same pool in the endpoint responses.