### PR TITLE
Fix infinite loop of loading PMs

### DIFF
--- a/frontend/src/components/PaginatedTable.js
+++ b/frontend/src/components/PaginatedTable.js
@@ -51,7 +51,7 @@ function PaginatedTable ({
 
   if (shouldLoadNextChunk) {
     const offset = Math.floor(startIndex / pageSize) * pageSize;
-    setTimeout(() => onLoad({ offset, filters, sortBy, filterKey }), 0);
+    setTimeout(() => onLoad({ offset, filters, sortBy, filterKey, limit: pageSize }), 0);
   }
 
   if (sortByRef.current !== sortBy) {

--- a/frontend/src/components/PaginatedTable.js
+++ b/frontend/src/components/PaginatedTable.js
@@ -78,7 +78,6 @@ function PaginatedTable ({
 
   const onChangeSizeChange = (newPageSize) => {
     dispatch(setPageSize(newPageSize));
-    onLoad({filters, sortBy, filterKey});
   };
 
   return (


### PR DESCRIPTION
Setting the page size to 100 in the Process Measurements table causes an infinite loop of requests for process measurements.

The problem is that the table wants 100 items, but isn't passing the page size limit to the listTable function, so the listTable function is using the default page size of 20. The table keeps asking for 100 items and 20 items are loaded, producing an infinite loop of listTable requests.

Passing the pageSize expected by the table fixes the problem, for PM's and for any other listTable functions that aren't grabbing the page size out of redux themselves.