### PR TITLE
Fix completed samples 100 limit

### DIFF
--- a/frontend/src/modules/studySamples/services.ts
+++ b/frontend/src/modules/studySamples/services.ts
@@ -203,7 +203,7 @@ export async function fetchSamplesAtStepOrder(studyID: FMSId, stepOrderID: FMSId
 		options = {ordering, ...serializedFilters}
 	}
 
-	return store.dispatch(api.sampleNextStepByStudy.getStudySamplesForStepOrder(studyID, stepOrderID, options))
+	return store.dispatch(api.sampleNextStepByStudy.getStudySamplesForStepOrder(studyID, stepOrderID, {...options, limit: 100000}))
 		.then(response => {
 			if (response.data?.results) {
 				return {

--- a/frontend/src/modules/studySamples/services.ts
+++ b/frontend/src/modules/studySamples/services.ts
@@ -46,7 +46,7 @@ export async function loadStudySamples(studyID: FMSId) {
 	
 	// Get samples that have completed the process at a step
 	let completedSamplesByStudy : FMSStepHistory[] | undefined
-	const sampleHistoryResponse = await store.dispatch(api.stepHistory.getCompletedSamplesForStudy(studyID))
+	const sampleHistoryResponse = await store.dispatch(api.stepHistory.getCompletedSamplesForStudy(studyID, {limit: 100000}))
 	if (sampleHistoryResponse.data.results) {
 		completedSamplesByStudy = sampleHistoryResponse.data.results as FMSStepHistory[]
 	} else {

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -243,7 +243,7 @@ const api = {
   },
 
   stepHistory: {
-    getCompletedSamplesForStudy: (studyId) => get('/step-histories/', {study__id__in: studyId}),
+    getCompletedSamplesForStudy: (studyId, options) => get('/step-histories/', {...options, study__id__in: studyId}),
     countStudySamples: (studyId) => get(`/step-histories/summary_by_study/`, {study__id__in: studyId})
   },
 


### PR DESCRIPTION
Fixes the issue with missing completed samples in the project study samples tables - only the first 100 samples were retrieved from the server because no limit was specified and the default limit of 100 was used.