### PR TITLE
QC: fix infinite loop in process measurements table

### DIFF
--- a/frontend/src/components/PaginatedTable.js
+++ b/frontend/src/components/PaginatedTable.js
@@ -51,7 +51,7 @@ function PaginatedTable ({
 
   if (shouldLoadNextChunk) {
     const offset = Math.floor(startIndex / pageSize) * pageSize;
-    setTimeout(() => onLoad({ offset, filters, sortBy, filterKey }), 0);
+    setTimeout(() => onLoad({ offset, filters, sortBy, filterKey, limit: pageSize }), 0);
   }
 
   if (sortByRef.current !== sortBy) {

--- a/frontend/src/components/PaginatedTable.js
+++ b/frontend/src/components/PaginatedTable.js
@@ -78,7 +78,6 @@ function PaginatedTable ({
 
   const onChangeSizeChange = (newPageSize) => {
     dispatch(setPageSize(newPageSize));
-    onLoad({filters, sortBy, filterKey});
   };
 
   return (


### PR DESCRIPTION
In the processes table, if you set the page size to 50 or 100 then freezeman would go into an infinite loop of requesting process measurements, because it was still asking for only 20 items (the default page size) and never loading 100 pm's.