### PR TITLE
Modified template submission error alert

### DIFF
--- a/frontend/src/components/templateFlow/TemplateFlow.js
+++ b/frontend/src/components/templateFlow/TemplateFlow.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { connect } from "react-redux"
 import PropTypes from "prop-types";
-import { Button, Steps, Row, Col } from "antd";
+import { Button, Steps, Row, Col, notification } from "antd";
 import { downloadFromFile } from "../../utils/download";
 
 import {
@@ -87,6 +87,16 @@ const TemplateFlow = ({ fetchListedData, fetchSummariesData, ...props }) => {
         setSubmitResult({ valid: true });
       })
       .catch(error => {
+        if (error.message === 'Failed to fetch') {
+          // If the template file was changed on disk since it was uploaded
+          // then a 'failed to fetch' error is thrown. This can happen if the user saves a change to
+          // the template after it has been uploaded.
+          notification.error({
+            message: 'Template Has Changed',
+            description: 'The template has changed since it was uploaded and cannot be submitted. Please upload the template again, and ensure that it is not saved or otherwise modified until after it has been submitted.',
+            duration: 0
+          })
+        }
         setSubmitResult({
           valid: false,
           error,

--- a/frontend/src/components/templateFlow/TemplateFlow.js
+++ b/frontend/src/components/templateFlow/TemplateFlow.js
@@ -91,9 +91,14 @@ const TemplateFlow = ({ fetchListedData, fetchSummariesData, ...props }) => {
           // If the template file was changed on disk since it was uploaded
           // then a 'failed to fetch' error is thrown. This can happen if the user saves a change to
           // the template after it has been uploaded.
+          const description = 
+            <div>
+              <p>The template has changed since it was uploaded and cannot be submitted.</p>
+              <p>Please upload the template again, and ensure that it is not saved or otherwise modified until after it has been submitted.</p>
+            </div>
           notification.error({
             message: 'Template Has Changed',
-            description: 'The template has changed since it was uploaded and cannot be submitted. Please upload the template again, and ensure that it is not saved or otherwise modified until after it has been submitted.',
+            description,
             duration: 0
           })
         }


### PR DESCRIPTION
If the user modifies a template after it has been uploaded then when they try to submit a 'failed to fetch' error is thrown. Catch the error and pop an error notification to explain why submit has failed.