### PR TITLE
Fixes 'Export samples' 'Export metadata'

### DIFF
--- a/frontend/src/components/ExportButton.js
+++ b/frontend/src/components/ExportButton.js
@@ -7,7 +7,7 @@ import { useAppDispatch } from "../hooks";
 import { notifyError } from "../modules/notification/actions";
 const { confirm } = Modal;
 
-const ExportButton = ({ exportFunction, filename, itemsCount, ...rest }) => {
+const ExportButton = ({ exportType, exportFunction, filename, itemsCount, ...rest }) => {
   const [loading, setLoading] = useState(false);
   const dispatch = useAppDispatch()
 
@@ -49,7 +49,7 @@ const ExportButton = ({ exportFunction, filename, itemsCount, ...rest }) => {
 
   }
   return (
-    <Button icon={<DownloadOutlined />} onClick={onClick} loading={loading} {...rest}>Export</Button>
+		<Button icon={<DownloadOutlined />} onClick={onClick} loading={loading} {...rest}>{exportType ? `Export ${exportType}` : 'Export'}</Button>
   )
 }
 


### PR DESCRIPTION
I removed the `exportType` prop from `ExportButton` because I didn't think it was used anywhere. I guess the extra space added in the button title was bothering me, "Export ". I didn't realize that ExportDropdown was using the `exportType` prop.