### PR TITLE
Remove redundant request for template actions in Dashboard

### DIFF
--- a/frontend/src/components/DashboardPage.js
+++ b/frontend/src/components/DashboardPage.js
@@ -1,17 +1,8 @@
-import React, {useEffect} from "react";
+import React from "react";
 import {connect} from "react-redux";
 import {Link} from "react-router-dom";
 import {Button, Card, Col, Row, Statistic} from "antd";
-
-import CONTAINERS from "../modules/containers/actions";
-import SAMPLES from "../modules/samples/actions";
-import LIBRARIES from "../modules/libraries/actions";
-import PROCESS_MEASUREMENTS from "../modules/processMeasurements/actions";
-import PROJECTS from "../modules/projects/actions";
-import INDICES from "../modules/indices/actions";
-
 import {actionsToButtonList, actionIcon} from "../utils/templateActions";
-
 import AppPageHeader from "./AppPageHeader";
 import PageContainer from "./PageContainer";
 import PageContent from "./PageContent";
@@ -45,17 +36,7 @@ const DashboardPage = ({
   protocolsByID,
   libraryTypesByID,
   templates,
-  listActions,
 }) => {
-  useEffect(() => {
-    listActions.container();
-    listActions.sample();
-    listActions.library();
-    listActions.process();
-    listActions.project();
-    listActions.indices();
-  }, []);
-
   return <PageContainer>
     <AppPageHeader title="Dashboard" />
     <PageContent style={{padding: "0 24px 24px 24px"}}>
@@ -197,15 +178,4 @@ const mapStateToProps = state => ({
   },
 });
 
-const mapDispatchToProps = dispatch => ({
-  listActions: {
-    container: () => dispatch(CONTAINERS.listTemplateActions()),
-    sample: () => dispatch(SAMPLES.listTemplateActions()),
-    library: () => dispatch(LIBRARIES.listTemplateActions()),
-    process: () => dispatch(PROCESS_MEASUREMENTS.listTemplateActions()),
-    project: () => dispatch(PROJECTS.listTemplateActions()),
-    indices: () => dispatch(INDICES.listTemplateActions()),
-  }
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(DashboardPage);
+export default connect(mapStateToProps)(DashboardPage);


### PR DESCRIPTION
Possible fix for broken action template download links in QC when connecting through an ssh tunnel.

We load the template actions when the app launches, but Dashboard was firing off it's own request to load the template actions. It's possible that this causes the strangeness on QC.

The second request for template actions by the dashboard is redundant and has been removed.

"Template actions url's are broken on QC"
https://206.12.92.46/issues/1765