### PR TITLE
Fixed "placeholder" bug

### DIFF
--- a/frontend/src/components/shared/WithItemRenderComponent.tsx
+++ b/frontend/src/components/shared/WithItemRenderComponent.tsx
@@ -79,9 +79,7 @@ function WithItemRenderComponentFactory<W extends WithItemFunc, T extends FMSTra
             return render(object)
         } else {
             if (placeholder) {
-                if (typeof placeholder === 'string') {
-                    return <span>placeholder</span>
-                } else return placeholder
+                return placeholder
             } else {
                 return null
             }


### PR DESCRIPTION
Doh. WithItemRenderComponent was rendering "placeholder" instead of the placeholder element. I got rid of the test for "string" and just return placeholder directly, since react will render the string.