### PR TITLE
Fixes nullish error in cache.ts reply handling

### DIFF
--- a/frontend/src/modules/cache/cache.ts
+++ b/frontend/src/modules/cache/cache.ts
@@ -12,6 +12,7 @@ import { list as listLibraries } from '../libraries/actions'
 import { list as listWorkflows } from '../workflows/actions'
 import { list as listStudies } from '../studies/actions'
 import { list as listContainers } from '../containers/actions'
+import { isDefined, isNullish } from "../../utils/functions"
 
 
 type ListByIDFunction = (ids: FMSId[]) => (dispatch: Dispatch, getState: () => any) => Promise<any>
@@ -41,12 +42,17 @@ function createFetchItems<ItemType extends FMSTrackedModel>(
 			// Some 'list' endpoints return paginated results, with a count and the data
 			// in a 'results' field. Others just return an array of data objects directly,
 			// so we have to distinguish between the two types of response.
-			if (reply.count && reply.results) {
-				fetchedItems.push(...reply.results)
-			} else {
+
+			if (Array.isArray(reply)) {
 				fetchedItems.push(...reply)
-			}
-			
+			} else {
+				if (isDefined(reply.count) && isDefined(reply.results)) {
+					fetchedItems.push(...reply.results)
+				} else {
+					console.error('Cache received unsupported reply from a list api call', JSON.stringify(reply))
+					throw new Error('Cache received unexpected reply from list api call')
+				}
+			}			
 		}
 
 		return fetchedItems

--- a/frontend/src/utils/functions.ts
+++ b/frontend/src/utils/functions.ts
@@ -5,3 +5,7 @@ export function constVal<T>(x: T) {
 export function isNullish(nullable: any): nullable is null | undefined {
     return nullable === undefined || nullable === null
 }
+
+export function isDefined(nullable: any) {
+    return !isNullish(nullable)
+}


### PR DESCRIPTION
A bad nullish check was causing the fetchXXX functions to throw an exception when a list function returned a reply with a zero count, ie: 
```
{
  count: 0,
  results: []
}
```