### PR TITLE
Fix missing sidebar

### DIFF
--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -34,14 +34,14 @@ import useUserInputExpiration from "../utils/useUserInputExpiration";
 import { useAppDispatch, useAppSelector } from "../hooks";
 import { setAppInitialized } from "../modules/app/actions";
 import { logOut } from "../modules/auth/actions";
-import { fetchLabworkSummary, fetchListedData, fetchStaticData, fetchSummariesData } from "../modules/shared/actions";
+import { fetchSummariesData, fetchStaticData, fetchLabworkSummary, fetchListedData } from "../modules/shared/actions";
 import { get } from "../modules/users/actions";
 import { selectAppInitialzed, selectAuthTokenAccess, } from "../selectors";
 import DatasetsPage from "./datasets/DatasetsPage";
 import LabworkPage from "./labwork/LabworkPage";
+import WorkflowDefinitionsRoute from "./workflows/WorkflowDefinitionsRoute";
 import ReferenceGenomesRoute from "./referenceGenomes/ReferenceGenomesRoute";
 import TaxonsRoute from "./taxons/TaxonsRoute";
-import WorkflowDefinitionsRoute from "./workflows/WorkflowDefinitionsRoute";
 
 
 const { Title } = Typography;

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -34,14 +34,14 @@ import useUserInputExpiration from "../utils/useUserInputExpiration";
 import { useAppDispatch, useAppSelector } from "../hooks";
 import { setAppInitialized } from "../modules/app/actions";
 import { logOut } from "../modules/auth/actions";
-import { fetchSummariesData, fetchStaticData, fetchLabworkSummary, fetchListedData } from "../modules/shared/actions";
+import { fetchLabworkSummary, fetchListedData, fetchStaticData, fetchSummariesData } from "../modules/shared/actions";
 import { get } from "../modules/users/actions";
 import { selectAppInitialzed, selectAuthTokenAccess, } from "../selectors";
 import DatasetsPage from "./datasets/DatasetsPage";
 import LabworkPage from "./labwork/LabworkPage";
-import WorkflowDefinitionsRoute from "./workflows/WorkflowDefinitionsRoute";
 import ReferenceGenomesRoute from "./referenceGenomes/ReferenceGenomesRoute";
 import TaxonsRoute from "./taxons/TaxonsRoute";
+import WorkflowDefinitionsRoute from "./workflows/WorkflowDefinitionsRoute";
 
 
 const { Title } = Typography;
@@ -203,12 +203,6 @@ const App = ({userID, usersByID, logOut, get}) => {
 
   const isLoggedIn = userID !== null;
   const user = usersByID[userID];
-
-  useEffect(() => {
-    if (!user && isLoggedIn) {
-      get(userID)
-    }
-  }, [user, userID, usersByID, get, isLoggedIn])
 
   const menuItems = getMenuItems(user, logOut);
 

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -56,6 +56,7 @@ const notificationError: ThunkMiddleware = ({ dispatch }) => next => action => {
 		return next(action)
 
 	if (action.error.message.includes(TOKEN_EXPIRED_MESSAGE)) {
+		console.error('Notification middleware detected an expired token error. Logging out', action)
 		dispatch(logOut())
 		return next(action)
 	}


### PR DESCRIPTION
Fixes an issue where the sidebar would mysteriously disappear from freezeman.

App.js only renders the sidebar if it finds a user ID in the auth state in redux. If there is no user ID then it skips the sidebar, but still renders the dashboard (which makes no sense - we should fix that someday).

Normally if there is no user ID then there will be no tokens either and users are bounced to the login page.

Somehow, we were ending up with a null user ID but valid tokens in the auth state, so most of the app functioned normally but the sidebar wouldn't render.

I think this was caused by a race condition. When the app starts up it checks any tokens it has (loaded from local storage into redux by the persist framework). If the access token is expired but the refresh token is still valid then it will use the refresh token to request a new access token. 

At the same time, App.js would attempt to load the current user object with the user `get` action, but with either the old expired token, or no token at all (not 100% sure), and this would result in an error response from the server.

The new notifications middleware checks all actions for errors. If it discovers a token error then it dispatches the logOut action automatically.

logOut flushes the auth state, setting the current user id to null, and flushing the tokens.

I think what happened was that there was a pending refresh api call that was completed after the auth state was flushed. The refresh was successful and the auth reducer ended up writing the new tokens into the auth state. Refresh only writes new tokens to the auth state, and keeps whatever user id was already in the state.

We end up with a null user id and the set of tokens, and freezeman falls apart. Since this gets written to local storage, the user ends up stuck with no sidebar until the tokens expire.

The fix is to stop trying to load the current user with `get` and simply wait for the app to finish loading the list of users into redux. Eventually the user will be loaded, the app will re-render, and all will be well.

