### PR TITLE
Fixes bug 1915

### DIFF
--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -55,7 +55,7 @@ const api = {
   },
 
   experimentRuns: {
-    get: experimentRunId => get(`/experiment-runs/${experimentRunId}`),
+    get: experimentRunId => get(`/experiment-runs/${experimentRunId}/`),
     list: (options, abort) => get("/experiment-runs/", options, {abort}),
     listExport: options => get("/experiment-runs/list_export/", {format: "csv", ...options}),
     listExternalRuns: (options, abort) => get("/experiment-runs/list_external_experiment_run/", {limit: 100000, ...options}, {abort}),


### PR DESCRIPTION
Foiled again by a missing `/` character at the end of an api call in api.js (experimentRuns.get).
