### PR TITLE
Placement Tweaks Tweaks

### DIFF
--- a/frontend/src/components/placementVisuals/AddPlacementContainer.tsx
+++ b/frontend/src/components/placementVisuals/AddPlacementContainer.tsx
@@ -74,9 +74,9 @@ const AddPlacementContainer = ({ onConfirm, existingContainers }: AddPlacementCo
             loadedSamples.forEach(sample => {
                 newDestination[sample.id] = {
                     id: sample.id,
-                    coordinates: sample.coordinate ? coordinates[sample.coordinate]?.name ?? '...' : 'undefined',
+                    coordinates: sample.coordinate ? coordinates[sample.coordinate]?.name ?? '...' : '-',
                     name: sample.name,
-                    project: sample.project ? projects[sample.project]?.name ?? '...' : 'undefined'
+                    project: sample.project ? projects[sample.project]?.name ?? '...' : '-'
                 }
             })
         }

--- a/frontend/src/components/placementVisuals/AddPlacementContainer.tsx
+++ b/frontend/src/components/placementVisuals/AddPlacementContainer.tsx
@@ -9,6 +9,7 @@ import api from "../../utils/api"
 import { MAX_CONTAINER_BARCODE_LENGTH, MAX_CONTAINER_NAME_LENGTH, barcodeRules, nameRules } from "../../constants"
 import { FMSContainer, FMSId, FMSSample } from "../../models/fms_api_models"
 import { get as getProject } from "../../modules/projects/actions"
+import store from "../../store"
 
 export interface DestinationContainer {
     container_barcode: string
@@ -33,8 +34,6 @@ const AddPlacementContainer = ({ onConfirm, existingContainers }: AddPlacementCo
     // make at least empty samples required for newly created container
     const [newContainer, setNewContainer] = useState<Pick<DestinationContainer, 'samples'> & Partial<DestinationContainer>>({ samples: {} })
 
-    const coordinates = useAppSelector(selectCoordinatesByID)
-    const projects = useAppSelector(selectProjectsByID)
     const containerKinds = useAppSelector(selectContainerKindsByID)
 
     const getContainerKindOptions = useCallback(() => {
@@ -69,17 +68,20 @@ const AddPlacementContainer = ({ onConfirm, existingContainers }: AddPlacementCo
             }
             await Promise.all(promises)
 
+            const coordinates = selectCoordinatesByID(store.getState())
+            const projects = selectProjectsByID(store.getState())
+
             loadedSamples.forEach(sample => {
                 newDestination[sample.id] = {
                     id: sample.id,
-                    coordinates: sample.coordinate ? coordinates[sample.coordinate]?.name ?? '...' : '',
+                    coordinates: sample.coordinate ? coordinates[sample.coordinate]?.name ?? '...' : 'N/A',
                     name: sample.name,
-                    project: sample.project ? projects[sample.project]?.name ?? '...' : ''
+                    project: sample.project ? projects[sample.project]?.name ?? '...' : 'N/A'
                 }
             })
         }
         setLoadedContainer({ container_barcode: containerBarcode, container_name: containerName, container_kind: container.kind, samples: { ...newDestination }, })
-    }, [coordinates, dispatch, projects])
+    }, [dispatch])
 
     //calls addDestination prop with 'New Destination' container
     const handleConfirm = useCallback(() => {

--- a/frontend/src/components/placementVisuals/AddPlacementContainer.tsx
+++ b/frontend/src/components/placementVisuals/AddPlacementContainer.tsx
@@ -74,9 +74,9 @@ const AddPlacementContainer = ({ onConfirm, existingContainers }: AddPlacementCo
             loadedSamples.forEach(sample => {
                 newDestination[sample.id] = {
                     id: sample.id,
-                    coordinates: sample.coordinate ? coordinates[sample.coordinate]?.name ?? '...' : 'N/A',
+                    coordinates: sample.coordinate ? coordinates[sample.coordinate]?.name ?? '...' : 'undefined',
                     name: sample.name,
-                    project: sample.project ? projects[sample.project]?.name ?? '...' : 'N/A'
+                    project: sample.project ? projects[sample.project]?.name ?? '...' : 'undefined'
                 }
             })
         }

--- a/frontend/src/components/placementVisuals/AddPlacementContainer.tsx
+++ b/frontend/src/components/placementVisuals/AddPlacementContainer.tsx
@@ -59,12 +59,16 @@ const AddPlacementContainer = ({ onConfirm, existingContainers }: AddPlacementCo
         const newDestination: DestinationContainer['samples']  = {}
         if (container.samples.length > 0) {
             const loadedSamples: FMSSample[] = (await dispatch(api.samples.list({ id__in: container.samples.join(','), limit: 100000 }))).data.results
+
             const projectIDs = new Set(loadedSamples.map(sample => sample.project))
+            const promises: Promise<any>[] = []
             for (const projectID of projectIDs) {
                 if (projectID) {
-                    dispatch(getProject(projectID))
+                    promises.push(dispatch(getProject(projectID)))
                 }
             }
+            await Promise.all(promises)
+
             loadedSamples.forEach(sample => {
                 newDestination[sample.id] = {
                     id: sample.id,

--- a/frontend/src/components/placementVisuals/Cell.tsx
+++ b/frontend/src/components/placementVisuals/Cell.tsx
@@ -74,7 +74,7 @@ const Cell = ({ container: containerName, coordinates, cellSize }: CellProps) =>
             content={<>
                 <div>{`Sample: ${sampleName}`}</div>
                 <div>{`Coordinates: ${cell.coordinates}`}</div>
-                {placedFrom && placedFrom.parentContainerName && <div>{`From: ${placedFrom.parentContainerName}@${placedFrom.coordinates}`}</div>}
+                {(placedFrom && placedFrom.parentContainerName) ? <div>{`From: ${placedFrom.parentContainerName}@${placedFrom.coordinates}`}</div> : <div>From: Tubes without parent</div>}
                 {placedAt && <div>{`At: ${placedAt.parentContainerName}@${placedAt.coordinates}`}</div>}
             </>}
             destroyTooltipOnHide={{ keepParent: false }}

--- a/frontend/src/components/placementVisuals/Cell.tsx
+++ b/frontend/src/components/placementVisuals/Cell.tsx
@@ -73,8 +73,9 @@ const Cell = ({ container: containerName, coordinates, cellSize }: CellProps) =>
         <Popover
             content={<>
                 <div>{`Sample: ${sampleName}`}</div>
-                <div>{`Coordinates: ${cell.coordinates}`}</div>
-                {(placedFrom && placedFrom.parentContainerName) ? <div>{`From: ${placedFrom.parentContainerName}@${placedFrom.coordinates}`}</div> : <div>From: Tubes without parent</div>}
+                <div>{`Coords: ${cell.coordinates}`}</div>
+                {placedFrom &&
+                    (placedFrom.parentContainerName ? <div>{`From: ${placedFrom.parentContainerName}@${placedFrom.coordinates}`}</div> : <div>From: Tubes without parent</div>)}
                 {placedAt && <div>{`At: ${placedAt.parentContainerName}@${placedAt.coordinates}`}</div>}
             </>}
             destroyTooltipOnHide={{ keepParent: false }}

--- a/frontend/src/components/placementVisuals/Placement.tsx
+++ b/frontend/src/components/placementVisuals/Placement.tsx
@@ -91,7 +91,7 @@ function Placement({ stepID, sampleIDs }: PlacementProps) {
                 coordinates: sample.coordinates,
                 sample: sample.id,
                 name: sample.name,
-                projectName: '', // should this be defined?
+                projectName: sample.project,
             }))
         }))
         const nextContainer = {

--- a/frontend/src/components/placementVisuals/PlacementSamplesTable.tsx
+++ b/frontend/src/components/placementVisuals/PlacementSamplesTable.tsx
@@ -160,7 +160,13 @@ const PlacementSamplesTable = ({ container: containerName, showContainerColumn }
 
     return (
         <Table<PlacementSample>
-            dataSource={samples.filter(sample => !sample.placed)}
+            dataSource={samples.filter(sample => !sample.placed).map(
+            (sample) => 
+                ({
+                    ...sample,
+                    parentContainerName: sample.parentContainerName ?? 'Tube without parent' 
+                })
+            )}
             columns={columns}
             rowKey={obj => obj.id}
             rowSelection={selectionProps}

--- a/frontend/src/components/placementVisuals/PlacementSamplesTable.tsx
+++ b/frontend/src/components/placementVisuals/PlacementSamplesTable.tsx
@@ -132,7 +132,8 @@ const PlacementSamplesTable = ({ container: containerName, showContainerColumn }
             return <>
                 <>{`${range[0]}-${range[1]} of ${total} items.`}</>
                 <>{' '}</>
-                <>{`${selectedRowKeys.length} selected.`}</>
+                <b style={{ color: '#1890ff' }}>{`${selectedRowKeys.length} selected`}</b>
+                .
             </>
         }
     }), [selectedRowKeys.length])

--- a/frontend/src/components/placementVisuals/PlacementSamplesTable.tsx
+++ b/frontend/src/components/placementVisuals/PlacementSamplesTable.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react"
-import { Table } from "antd";
+import { Space, Table, TableProps } from "antd";
 import { ColumnsType, SelectionSelectFn, TableRowSelection } from "antd/lib/table/interface";
 import { FMSId } from "../../models/fms_api_models";
 import { useAppDispatch, useAppSelector } from "../../hooks";
@@ -126,6 +126,17 @@ const PlacementSamplesTable = ({ container: containerName, showContainerColumn }
         })
     }), [selectedRowKeys, onChange, onSelect, isDestination, containerName])
 
+    const paginationProps: NonNullable<TableProps<PlacementSample>['pagination']> = useMemo(() => ({
+        showSizeChanger: true,
+        showTotal(total, range) {
+            return <>
+                <>{`${range[0]}-${range[1]} of ${total} items.`}</>
+                <>{' '}</>
+                <>{`${selectedRowKeys.length} selected.`}</>
+            </>
+        }
+    }), [selectedRowKeys.length])
+
     const columns = useMemo(() => {
         const columns: ColumnsType<PlacementSample> = []
 
@@ -173,7 +184,7 @@ const PlacementSamplesTable = ({ container: containerName, showContainerColumn }
             columns={columns}
             rowKey={obj => obj.id}
             rowSelection={selectionProps}
-            pagination={{ showSizeChanger: true }}
+            pagination={paginationProps}
         />
     )
 }

--- a/frontend/src/components/placementVisuals/PlacementSamplesTable.tsx
+++ b/frontend/src/components/placementVisuals/PlacementSamplesTable.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react"
-import { Space, Table, TableProps } from "antd";
+import { Table, TableProps } from "antd";
 import { ColumnsType, SelectionSelectFn, TableRowSelection } from "antd/lib/table/interface";
 import { FMSId } from "../../models/fms_api_models";
 import { useAppDispatch, useAppSelector } from "../../hooks";

--- a/frontend/src/components/placementVisuals/PlacementSamplesTable.tsx
+++ b/frontend/src/components/placementVisuals/PlacementSamplesTable.tsx
@@ -121,7 +121,10 @@ const PlacementSamplesTable = ({ container: containerName, showContainerColumn }
         selectedRowKeys,
         onChange,
         onSelect,
-    }), [selectedRowKeys, onChange, onSelect])
+        getCheckboxProps: (sample) => ({
+            disabled: isDestination && sample.parentContainerName === containerName
+        })
+    }), [selectedRowKeys, onChange, onSelect, isDestination, containerName])
 
     const columns = useMemo(() => {
         const columns: ColumnsType<PlacementSample> = []
@@ -164,7 +167,7 @@ const PlacementSamplesTable = ({ container: containerName, showContainerColumn }
             (sample) => 
                 ({
                     ...sample,
-                    parentContainerName: sample.parentContainerName ?? 'Tube without parent' 
+                    parentContainerName: sample.parentContainerName ?? 'Tubes without parent' 
                 })
             )}
             columns={columns}


### PR DESCRIPTION
- [x] show selection count under tables
- [x] show 'Tubes without parent' in table and in cell popup
- [x] show project name for existing destination container added
- [x] disable selection for samples already present on the destination side (by selecting through the tables)