### PR TITLE
Improve project interaction in LabWork

### DIFF
--- a/frontend/src/components/labwork/overview/LabworkOverviewProtocols.tsx
+++ b/frontend/src/components/labwork/overview/LabworkOverviewProtocols.tsx
@@ -42,7 +42,6 @@ const LabworkOverviewProtocols = ({ summary, hideEmptySections, refreshing }: La
 			return aIndex - bIndex
 		})
 	}, [protocols])
-	console.info(sortedProtocols)
 
 	function handleHideEmptySections(hide: boolean) {
 		dispatch(setHideEmptySections(hide))

--- a/frontend/src/components/labwork/step/LabworkStepOverview.tsx
+++ b/frontend/src/components/labwork/step/LabworkStepOverview.tsx
@@ -1,5 +1,5 @@
 import { Collapse, Typography, Button, Space, Tag, notification } from 'antd'
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useState, useEffect, useCallback, useMemo } from 'react'
 import { useAppDispatch, useAppSelector } from '../../../hooks'
 import { FILTER_TYPE } from '../../../constants'
 import { getLabworkStepSummary, setSelectedSamples, setSelectedSamplesInGroups, unselectSamples } from '../../../modules/labworkSteps/actions'
@@ -14,6 +14,7 @@ import { PaginationParameters } from '../../WorkflowSamplesTable/WorkflowSamples
 import { FilterDescription, FilterDescriptionSet, FilterKeySet, FilterSet, FilterValue, SetSortByFunc, SortBy } from '../../../models/paged_items'
 import { LabworkStepSamples, LabworkStepSamplesGroup } from '../../../modules/labworkSteps/models'
 import { mergeArraysIntoSet } from '../../../utils/mergeArraysIntoSet'
+import { SampleColumnID } from '../../samples/SampleTableColumns'
 
 const { Title } = Typography
 
@@ -41,7 +42,7 @@ export interface LabworkStepOverviewProps {
 const MAX_STEP_SAMPLE_SELECTION = 1000
 
 // If the filters do not work as expectd, check the filtering rules for sample_next_step endpoint (e.g. /backend/fms_core/viewsets/_constants.py, /backend/fms_core/filters.py)
-export const GROUPING_PROJECT = {type: FILTER_TYPE.INPUT, label: "Project", key: "project_name"}
+export const GROUPING_PROJECT = {type: FILTER_TYPE.INPUT, label: "Project", key: "sample__derived_by_samples__project__name"}
 export const GROUPING_CONTAINER = {type: FILTER_TYPE.INPUT, label: "Container", key: "ordering_container_name"}
 export const GROUPING_CREATION_DATE = {type: FILTER_TYPE.DATE_RANGE, label: "Creation Date", key: "sample__creation_date"}
 export const GROUPING_CREATED_BY = {type: FILTER_TYPE.INPUT, label: "Created By", key: "sample__created_by__username"}
@@ -90,6 +91,16 @@ const LabworkStepOverview = ({step, refreshing, stepSamples, columns, filterDefi
     dispatch(unselectSamples(step.id, groupSampleIds))
   }, [dispatch, step.id])
 
+  const finalColumns = useMemo(() => {
+    let finalColumns = [...columns]
+    switch (activeGrouping) {
+      case GROUPING_PROJECT:
+        finalColumns = finalColumns.filter(col => col.columnID !== SampleColumnID.PROJECT)
+        break
+    }
+    return finalColumns
+  }, [activeGrouping, columns])
+
 	return (
 		<>
       <div>
@@ -119,7 +130,7 @@ const LabworkStepOverview = ({step, refreshing, stepSamples, columns, filterDefi
 							  groupingValue={group.name}
 							  clearFilters={clearFilters}
 							  hasFilter={true}
-							  columns={columns}
+							  columns={finalColumns}
 							  filterDefinitions={filterDefinitions}
 							  filterKeys={filterKeys}
 							  filters={filters}

--- a/frontend/src/components/labwork/step/LabworkStepOverviewPanel.tsx
+++ b/frontend/src/components/labwork/step/LabworkStepOverviewPanel.tsx
@@ -52,8 +52,7 @@ const LabworkStepOverviewPanel = ({ stepID, refreshing, grouping, groupingValue,
 		if (!pagination?.pageNumber || !pagination?.pageSize || !filters || !filters[grouping.key]) {
 			return
 		}
-		const samples = await dispatch(loadSampleNextStepsAtStep(stepID, pagination.pageNumber, pagination.pageSize))
-		setSampleAndLibraryList(await fetchSamplesAndLibrariesAndIdentities(samples.results.map((sample) => sample.sample)))
+		dispatch(loadSampleNextStepsAtStep(stepID, pagination.pageNumber, pagination.pageSize))
 		setIsFetchingSamples(false)
 	}, [dispatch, filters, grouping.key, pagination?.pageNumber, pagination?.pageSize, stepID])
 
@@ -62,8 +61,11 @@ const LabworkStepOverviewPanel = ({ stepID, refreshing, grouping, groupingValue,
 	}, [initialSampleFetch])
 
   useEffect(() => {
-    const updateDisplay = async () => setSampleAndLibraryList(await fetchSamplesAndLibrariesAndIdentities(displayedSamples))
-    updateDisplay()
+    (async () => {
+		setIsFetchingSamples(true)
+		setSampleAndLibraryList(await fetchSamplesAndLibrariesAndIdentities(displayedSamples))
+		setIsFetchingSamples(false)
+	})()
   }, [displayedSamples]) // Triggers off filters instead of displayed samples to prevent endless loop. TODO fix loopy behaviour ... 
 
 	return (

--- a/frontend/src/components/samples/SampleTableColumns.tsx
+++ b/frontend/src/components/samples/SampleTableColumns.tsx
@@ -524,7 +524,7 @@ export const SAMPLE_NEXT_STEP_FILTER_KEYS: { [key in SampleColumnID]: string } =
 	[SampleColumnID.CREATION_DATE]: 'sample__creation_date',
 	[SampleColumnID.DEPLETED]: 'sample__depleted',
 	[SampleColumnID.QC_FLAG]: 'qc_flag',
-	[SampleColumnID.PROJECT]: 'project_name',
+	[SampleColumnID.PROJECT]: 'sample__derived_by_samples__project__name',
 	[SampleColumnID.COHORT]: 'sample__derived_samples__biosample__individual__cohort',
 	[SampleColumnID.QUEUED_STEPS]: 'step__name',
 	[SampleColumnID.SAMPLE_COUNT]: '',


### PR DESCRIPTION
https://redmine.c3g-app.sd4h.ca/issues/2609

- [x] Remove project filter when category is set to project
- [x] Project filter works for pools (in other categories)
- [x] Allow sample pools to show up in different projects and be only selectable once. 