### PR TITLE
the scrollable ExperiementRunsDetailsContent issue is corrected

### DIFF
--- a/frontend/src/components/experimentRuns/ExperimentRunsDetailContent.tsx
+++ b/frontend/src/components/experimentRuns/ExperimentRunsDetailContent.tsx
@@ -26,7 +26,7 @@ const { TabPane } = Tabs
 
 const pageStyle = {
 	padding: 0,
-	overflow: 'hidden',
+	overflow: 'scroll',
 }
 
 /*


### PR DESCRIPTION
This is issue Number 2792. It was a css issue on the overflow attribute to bet set to scroll instead of hidden