### PR TITLE
the counter on the sample rename component is fixed

### DIFF
--- a/frontend/src/utils/tableHooks.tsx
+++ b/frontend/src/utils/tableHooks.tsx
@@ -149,13 +149,16 @@ export function usePaginationProps(defaultPageSize: number): [
         setPageSize(defaultPageSize)
     }, [defaultPageSize])
 
+    const showTotal = useCallback((total: number, range: [number, number]) => `${range[0]}-${range[1]} of ${total} items`, [])
+
     return [
         {
             current: pageNumber,
             pageSize,
             total: totalCount,
             onChange,
-            align: 'end'
+            align: 'end',
+            showTotal,
         },
         {
             setPagination,


### PR DESCRIPTION
the sample rename component counter was missing. It is now fixed. 