### PR TITLE
Labwork page taking half page

### DIFF
--- a/frontend/src/components/labwork/overview/LabworkOverview.tsx
+++ b/frontend/src/components/labwork/overview/LabworkOverview.tsx
@@ -18,7 +18,7 @@ const LabworkOverview = ({state} : LabworkOverviewProps) => {
 		<>
 			<AppPageHeader title="Lab Work" />
 
-			<PageContent loading={loading} style={{maxWidth: '50rem'} as any}>
+			<PageContent loading={loading} /*style={{maxWidth: '50rem'} as any}*/>
 				{state.summary && 
           <div>
 					  <LabworkOverviewProtocols summary={state.summary} hideEmptySections={state.hideEmptySections} refreshing={refreshing}/>

--- a/frontend/src/components/samples/details/SampleDetailsContent.js
+++ b/frontend/src/components/samples/details/SampleDetailsContent.js
@@ -39,7 +39,7 @@ const depletedStyle = {
 
 const pageStyle = {
   padding: 0,
-  overflow: "scroll",
+  overflow: "hidden",
 }
 
 const tabStyle = {

--- a/frontend/src/components/samples/details/SampleDetailsContent.js
+++ b/frontend/src/components/samples/details/SampleDetailsContent.js
@@ -39,7 +39,7 @@ const depletedStyle = {
 
 const pageStyle = {
   padding: 0,
-  overflow: "hidden",
+  overflow: "scroll",
 }
 
 const tabStyle = {

--- a/frontend/src/hooks/usePaginatedList.js
+++ b/frontend/src/hooks/usePaginatedList.js
@@ -88,7 +88,7 @@ export const usePaginatedList = ({
             loading: loading || isCurrentPageUnloaded,
             childrenColumnName: 'UNEXISTENT_KEY',
             onChange: onChangeTable,
-            scroll :{ x: '100%', y: '50vh' },
+            scroll: { x: '100%', y: '50vh' },
         },
         paginationProps: {
             className: "ant-table-pagination ant-table-pagination-right",

--- a/frontend/src/hooks/usePaginatedList.js
+++ b/frontend/src/hooks/usePaginatedList.js
@@ -88,7 +88,7 @@ export const usePaginatedList = ({
             loading: loading || isCurrentPageUnloaded,
             childrenColumnName: 'UNEXISTENT_KEY',
             onChange: onChangeTable,
-            scroll: { x: 300 },
+            scroll :{ x: '100%', y: '50vh' },
         },
         paginationProps: {
             className: "ant-table-pagination ant-table-pagination-right",


### PR DESCRIPTION
The page content of the LabworkOverview component had a maxWidth: '50rem' style set as a property. 
I wonder why. I have commented it out. 