### PR TITLE
Fix LabWork page layout and create new PR 

### DIFF
--- a/frontend/src/components/labwork/overview/LabworkOverview.tsx
+++ b/frontend/src/components/labwork/overview/LabworkOverview.tsx
@@ -18,9 +18,9 @@ const LabworkOverview = ({state} : LabworkOverviewProps) => {
 		<>
 			<AppPageHeader title="Lab Work" />
 
-			<PageContent loading={loading} /*style={{maxWidth: '50rem'} as any}*/>
+			<PageContent loading={loading} >
 				{state.summary && 
-          <div>
+          <div style={{maxWidth: '50rem'} as any}>
 					  <LabworkOverviewProtocols summary={state.summary} hideEmptySections={state.hideEmptySections} refreshing={refreshing}/>
             <div style={{ padding: '1rem' }}></div>
             <LabworkOverviewAutomations summary={state.summary} hideEmptySections={state.hideEmptySections}/>

--- a/frontend/src/components/labwork/overview/LabworkOverview.tsx
+++ b/frontend/src/components/labwork/overview/LabworkOverview.tsx
@@ -18,7 +18,7 @@ const LabworkOverview = ({state} : LabworkOverviewProps) => {
 		<>
 			<AppPageHeader title="Lab Work" />
 
-			<PageContent loading={loading} style={{maxWidth: '50rem'} as any}>
+			<PageContent loading={loading} /*style={{maxWidth: '50rem'} as any}*/>
 				{state.summary && 
           <div>
 					  <LabworkOverviewProtocols summary={state.summary} hideEmptySections={state.hideEmptySections} refreshing={refreshing}/>


### PR DESCRIPTION
This PR replaces the previous incorrect PR (#1142), which will be closed.

Amendment:
The content page of the LabworkOverview component had a `maxWidth: '50rem'` style set on the PageContent component. I commented it out.