### PR TITLE
Allow renaming pools using the sample edit form.

### DIFF
--- a/frontend/src/components/samples/SampleEditContent.js
+++ b/frontend/src/components/samples/SampleEditContent.js
@@ -457,7 +457,7 @@ function deserialize(values) {
     newValues.coordinate = Number(newValues.coordinate)
 
   if (newValues.sample_kind === null){
-    newValues.sample_kind = 0 // Fake Pool sample kind
+    newValues.sample_kind = INVALID_FMS_ID // Fake Pool sample kind
   }
   else if (newValues.sample_kind) {
     newValues.sample_kind = Number(newValues.sample_kind)

--- a/frontend/src/components/samples/SampleEditContent.js
+++ b/frontend/src/components/samples/SampleEditContent.js
@@ -285,7 +285,7 @@ const SampleEditContent = ({ sample, isAdding}) => {
             extra="Name originally given by the client. Defaults to the name if left empty." >
             <Input />
           </Item>
-          <Item label="Sample Kind" {...props("sample_kind")} rules={requiredRules}
+          <Item label="Sample Kind" {...props("sample_kind")}
             extra="Biosample nature." >
             <Select
               options={sampleKindOptions}

--- a/frontend/src/components/samples/SampleEditContent.js
+++ b/frontend/src/components/samples/SampleEditContent.js
@@ -18,7 +18,7 @@ const { Item } = Form
 const { TextArea } = Input
 
 import { nameWithoutDotRules, requiredRules } from "../../constants";
-import { sample as EMPTY_SAMPLE, pool_sample_kind as POOL_KIND } from "../../models/empty_models";
+import { sample as EMPTY_SAMPLE, pool_sample_kind as POOL_KIND, INVALID_FMS_ID } from "../../models/empty_models";
 import { add, update } from "../../modules/samples/actions";
 import SamplesTableActions from '../../modules/samplesTable/actions'
 import { selectAppInitialized, selectAuthTokenAccess, selectContainerKindsByID, selectSampleKindsState, selectSamplesByID } from "../../selectors";
@@ -166,7 +166,7 @@ const SampleEditContent = ({ sample, isAdding}) => {
   const [sampleKindOptions, setSampleKindOptions] = useState(sampleKindsSorted.map(Options.renderSampleKind))
   const onFocusSampleKind = ev => { onSearchSampleKind(ev.target.value) }
   const onSearchSampleKind = useCallback(input => {
-    const sampleKindOptions = sample.is_pool ? [POOL_KIND] : input ?  [sampleKinds.itemsByID[input]] : [...sampleKindsSorted]
+    const sampleKindOptions = sample.is_pool ? [POOL_KIND] : (input ? [sampleKinds.itemsByID[input]] : [...sampleKindsSorted])
     setSampleKindOptions(sampleKindOptions.map(Options.renderSampleKind))
   }, [sampleKinds])
 
@@ -530,7 +530,7 @@ function serializeFormData(form) {
     newValues.container = Number(form.getFieldValue("container"))
   }
 
-  if (form.getFieldValue("sample_kind") === 0){
+  if (form.getFieldValue("sample_kind") === INVALID_FMS_ID){
     newValues.sample_kind = null // remove fake pool sample kind from request
   }
   else if (form.getFieldValue("sample_kind")) {

--- a/frontend/src/components/samples/SampleEditContent.js
+++ b/frontend/src/components/samples/SampleEditContent.js
@@ -18,7 +18,7 @@ const { Item } = Form
 const { TextArea } = Input
 
 import { nameWithoutDotRules, requiredRules } from "../../constants";
-import { sample as EMPTY_SAMPLE } from "../../models/empty_models";
+import { sample as EMPTY_SAMPLE, pool_sample_kind as POOL_KIND } from "../../models/empty_models";
 import { add, update } from "../../modules/samples/actions";
 import SamplesTableActions from '../../modules/samplesTable/actions'
 import { selectAppInitialized, selectAuthTokenAccess, selectContainerKindsByID, selectSampleKindsState, selectSamplesByID } from "../../selectors";
@@ -166,7 +166,7 @@ const SampleEditContent = ({ sample, isAdding}) => {
   const [sampleKindOptions, setSampleKindOptions] = useState(sampleKindsSorted.map(Options.renderSampleKind))
   const onFocusSampleKind = ev => { onSearchSampleKind(ev.target.value) }
   const onSearchSampleKind = useCallback(input => {
-    const sampleKindOptions = input ? [sampleKinds.itemsByID[input]] : [...sampleKinds.items]
+    const sampleKindOptions = sample.is_pool ? [POOL_KIND] : input ?  [sampleKinds.itemsByID[input]] : [...sampleKindsSorted]
     setSampleKindOptions(sampleKindOptions.map(Options.renderSampleKind))
   }, [sampleKinds])
 
@@ -285,7 +285,7 @@ const SampleEditContent = ({ sample, isAdding}) => {
             extra="Name originally given by the client. Defaults to the name if left empty." >
             <Input />
           </Item>
-          <Item label="Sample Kind" {...props("sample_kind")}
+          <Item label="Sample Kind" {...props("sample_kind")} rules={requiredRules}
             extra="Biosample nature." >
             <Select
               options={sampleKindOptions}
@@ -455,9 +455,9 @@ function deserialize(values) {
 
   if (newValues.coordinate)
     newValues.coordinate = Number(newValues.coordinate)
-
-  if (newValues.sample_kind)
-    newValues.sample_kind = Number(newValues.sample_kind)
+  
+  if (newValues.sample_kind === null)
+    newValues.sample_kind = 0
 
   if (newValues.experimental_group === null)
     newValues.experimental_group = []
@@ -526,8 +526,12 @@ function serializeFormData(form) {
     newValues.container = Number(form.getFieldValue("container"))
   }
 
-  if (form.getFieldValue("sample_kind"))
+  if (form.getFieldValue("sample_kind") === 0){
+    newValues.sample_kind = null
+  }
+  else if (form.getFieldValue("sample_kind")) {
     newValues.sample_kind = Number(form.getFieldValue("sample_kind"))
+  }
 
   if (!form.getFieldValue("individual")) {
     newValues.individual = ""

--- a/frontend/src/components/samples/SampleEditContent.js
+++ b/frontend/src/components/samples/SampleEditContent.js
@@ -455,9 +455,13 @@ function deserialize(values) {
 
   if (newValues.coordinate)
     newValues.coordinate = Number(newValues.coordinate)
-  
-  if (newValues.sample_kind === null)
-    newValues.sample_kind = 0
+
+  if (newValues.sample_kind === null){
+    newValues.sample_kind = 0 // Fake Pool sample kind
+  }
+  else if (newValues.sample_kind) {
+    newValues.sample_kind = Number(newValues.sample_kind)
+  }
 
   if (newValues.experimental_group === null)
     newValues.experimental_group = []
@@ -527,7 +531,7 @@ function serializeFormData(form) {
   }
 
   if (form.getFieldValue("sample_kind") === 0){
-    newValues.sample_kind = null
+    newValues.sample_kind = null // remove fake pool sample kind from request
   }
   else if (form.getFieldValue("sample_kind")) {
     newValues.sample_kind = Number(form.getFieldValue("sample_kind"))

--- a/frontend/src/models/empty_models.ts
+++ b/frontend/src/models/empty_models.ts
@@ -4,6 +4,8 @@
 
 import { FMSSample, FMSSampleKind } from "./fms_api_models"
 
+export const INVALID_FMS_ID = 0
+
 export const container = {
     kind: null,
     name: "",
@@ -37,7 +39,7 @@ export const sample = {
 } as const
 
 export const pool_sample_kind : FMSSampleKind = {
-  id: 0,
+  id: INVALID_FMS_ID,
   name: "POOL",
 } as const
 

--- a/frontend/src/models/empty_models.ts
+++ b/frontend/src/models/empty_models.ts
@@ -2,7 +2,7 @@
  * Empty model objects that are used by forms to create new items.
  */
 
-import { FMSSample } from "./fms_api_models"
+import { FMSSample, FMSSampleKind } from "./fms_api_models"
 
 export const container = {
     kind: null,
@@ -35,39 +35,44 @@ export const sample = {
   extracted_from: null, // sample.id
   project: null // project.id
 } as const
-  
-  export const individual = {
-    name: "",
-    taxon: null, // taxon.id
-    reference_genome: null, // reference_genome.id
-    sex: null,
-    pedigree: "",
-    cohort: "",
-    mother: null,
-    father: null
-  } as const
-  
-  export const user = {
-    username: "",
-    first_name: null,
-    last_name: null,
-    email: null,
-    password: "",
-    groups: [],
-    // user_permissions: [], // To be implemented maybe
-    is_staff: false,
-    is_superuser: false,
-    is_active: true, // To soft-delete the user
-    // last_login: null,
-    date_joined: null,
-  } as const
-  
-  export const project = {
-    name: "",
-    principal_investigator: "",
-    requestor_name: "",
-    requestor_email: "",
-    targeted_end_date: "",
-    status: "Open",
-    comment: "",
-  } as const
+
+export const pool_sample_kind : FMSSampleKind = {
+  id: 0,
+  name: "POOL",
+} as const
+
+export const individual = {
+  name: "",
+  taxon: null, // taxon.id
+  reference_genome: null, // reference_genome.id
+  sex: null,
+  pedigree: "",
+  cohort: "",
+  mother: null,
+  father: null
+} as const
+
+export const user = {
+  username: "",
+  first_name: null,
+  last_name: null,
+  email: null,
+  password: "",
+  groups: [],
+  // user_permissions: [], // To be implemented maybe
+  is_staff: false,
+  is_superuser: false,
+  is_active: true, // To soft-delete the user
+  // last_login: null,
+  date_joined: null,
+} as const
+
+export const project = {
+  name: "",
+  principal_investigator: "",
+  requestor_name: "",
+  requestor_email: "",
+  targeted_end_date: "",
+  status: "Open",
+  comment: "",
+} as const


### PR DESCRIPTION
The backend ignores this field anyway when the sample is a pool.