### PR TITLE
External project overview landing page

### DIFF
--- a/frontend/src/components/projectOverview/ExternalProjectsPage.tsx
+++ b/frontend/src/components/projectOverview/ExternalProjectsPage.tsx
@@ -1,7 +1,7 @@
 
 import { Alert, Button, Input, Table, Tag } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import AppPageHeader from '../AppPageHeader'
 import { Link } from 'react-router-dom'
 import { FMSProject,FMSParentProject } from '../../models/fms_api_models'
@@ -92,7 +92,7 @@ const ExternalProjectsPage = () => {
 
 	const clearFilters = useCallback(() => {setFilters({})}, [])
 
-	const parentProjectColumns: ColumnsType<FMSParentProject> = [
+	const parentProjectColumns =useMemo<ColumnsType<FMSParentProject>>(()=> [
 		{
 			title: 'External Project ID',
 			dataIndex: 'external_id',
@@ -169,7 +169,7 @@ const ExternalProjectsPage = () => {
 				)
 			},
 		},
-	]
+	], [filters, setFilters])
 
 	const dispatch = useAppDispatch()
 
@@ -256,9 +256,16 @@ const ExternalProjectsPage = () => {
 					loading={isLoading}
 					
 					expandable={{
-    					expandedRowRender: (parentProject) => {const internalProjects = (parentProject.projects ?? [])
-            				.map((projectID) => internalProjectsByID[projectID])
-							.filter((project): project is FMSProject =>project !== undefined)
+    					expandedRowRender: (parentProject) => {
+							const internalProjects = (parentProject.projects ?? []).reduce<FMSProject[]>(
+								(projects, projectID) => {
+									const project = internalProjectsByID[projectID]
+									if (project) {
+										projects.push(project)
+									}
+									return projects
+								},[]
+							)
 							return (
 								<Table
 									size="small"
@@ -268,7 +275,7 @@ const ExternalProjectsPage = () => {
 									pagination={false}
 								/>
 							)
-                           },
+                        },
                     }}
 					pagination={{
 						pageSize: 20,

--- a/frontend/src/components/projectOverview/ExternalProjectsPage.tsx
+++ b/frontend/src/components/projectOverview/ExternalProjectsPage.tsx
@@ -62,6 +62,25 @@ const internalProjectColumns: ColumnsType<FMSProject> = [
 	},
 ]
 
+// Organise les projets internes dans un objet afin de pouvoir retrouver rapidement chaque projet à partir de son ID.
+const indexProjectsByID = (projects: FMSProject[]): Partial<Record<number, FMSProject>> => 
+	projects.reduce<Partial<Record<number, FMSProject>>>((projectsByID, project) => {
+        projectsByID[project.id] = project
+        return projectsByID
+    }, {})
+
+
+// Récupère les IDs uniques des projets internes associés aux projets externes.
+const getUniqueInternalProjectIDs = (parentProjects: FMSParentProject[]): number[] => [
+    ...new Set(
+        parentProjects.flatMap(
+            (parentProject) =>
+                parentProject.projects ?? []
+        )
+    ),
+]
+
+
 
 const ExternalProjectsPage = () => {
 	const [parentProjects, setParentProjects] = useState<FMSParentProject[]>([])
@@ -154,48 +173,52 @@ const ExternalProjectsPage = () => {
 
 	const dispatch = useAppDispatch()
 
-	const fetchProjectsByExternalID = useCallback(async () => {
+
+	// Charge depuis l’API la liste des projets parents, triés par identifiant externe.
+	const fetchParentProjects = useCallback(
+        async (): Promise<FMSParentProject[]> => {
+            const response = await dispatch(
+				api.parentProjects.list(
+				{
+					limit: 100000,
+					ordering: 'external_id',
+				},true,),)
+            return response.data.results
+        },[dispatch],)
+
+
+	// Charge depuis l’API les projets internes correspondant aux IDs reçus, 
+	// ou retourne une liste vide si aucun ID n’est fourni.
+	const fetchInternalProjectsByIDs = useCallback(
+		async (projectIDs: number[],): Promise<FMSProject[]> => {
+        if (projectIDs.length === 0) {return []}
+
+        const response = await dispatch(
+			api.projects.list(
+				{
+					id__in: projectIDs.join(','),
+					limit: 100000,
+				}
+				,true,),
+        )
+
+        return response.data.results
+    },[dispatch],)
+
+
+
+	const fetchParentProjectsWithInternalProjects = useCallback(async () => {
 		try {
 			setIsLoading(true)
 			setError(null)
 
-			const response = await dispatch(
-				api.parentProjects.list({limit: 100000,ordering: 'external_id',},true,),
-			)
-			
-			const fetchedParentProjects = response.data.results
+			const fetchedParentProjects = await fetchParentProjects()
 			setParentProjects(fetchedParentProjects)
 
-			const internalProjectIDs = [
-                ...new Set(fetchedParentProjects.flatMap((parentProject) => parentProject.projects ?? [])),
-			]
-			
-
-			if (internalProjectIDs.length > 0) {
-    			const internalProjectsResponse = await dispatch(
-        		api.projects.list(
-            		{
-                		id__in: internalProjectIDs.join(','),
-                		limit: 100000,
-            		},
-            	true,
-        			),
-    			)
-
-    		const fetchedInternalProjects = internalProjectsResponse.data.results
-			
-			const fetchedInternalProjectsByID = fetchedInternalProjects.reduce<Partial<Record<number, FMSProject>>>(
-				(projectsByID, project) => {
-					projectsByID[project.id] = project
-					return projectsByID
-				}, {})
-
+			const internalProjectIDs = getUniqueInternalProjectIDs(fetchedParentProjects)
+			const fetchedInternalProjects = await fetchInternalProjectsByIDs(internalProjectIDs)
+			const fetchedInternalProjectsByID = indexProjectsByID(fetchedInternalProjects)
 			setInternalProjectsByID(fetchedInternalProjectsByID)
-			} 
-			else 
-			{
-    		    setInternalProjectsByID({})
-			}
 		} 
 		catch (error) {
 
@@ -208,11 +231,11 @@ const ExternalProjectsPage = () => {
 		finally {
 			setIsLoading(false)
 		}
-	}, [dispatch])
+	}, [fetchParentProjects,fetchInternalProjectsByIDs])
 
 	useEffect(() => {
-		fetchProjectsByExternalID()
-	}, [fetchProjectsByExternalID])
+		fetchParentProjectsWithInternalProjects()
+	}, [fetchParentProjectsWithInternalProjects])
 
 	
 	return (

--- a/frontend/src/components/projectOverview/ExternalProjectsPage.tsx
+++ b/frontend/src/components/projectOverview/ExternalProjectsPage.tsx
@@ -1,5 +1,5 @@
 
-import { Alert, Button, Input, Table, Tag } from 'antd'
+import { Alert, Table, Tag } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import AppPageHeader from '../AppPageHeader'
@@ -10,14 +10,22 @@ import api from '../../utils/api'
 import PageContent from '../PageContent'
 
 import { useAppDispatch } from '../../hooks'
-import { SearchOutlined } from '@ant-design/icons'
 
 import FiltersBar from '../filters/filtersBar/FiltersBar'
-import { FilterSet } from '../../models/paged_items'
+import {FilterDescription,FilterSet,SetFilterFunc,} from '../../models/paged_items'
+
+import { getFilterPropsForDescription } from '../filters/getFilterPropsTS'
+import { setFilterValue } from '../../models/filter_set_reducers'
 
 
 
 const EXTERNAL_PROJECT_NAME_FILTER_KEY = 'external_project_name'
+const EXTERNAL_PROJECT_NAME_FILTER_DESCRIPTION: FilterDescription = {
+	type: 'INPUT',
+	key: EXTERNAL_PROJECT_NAME_FILTER_KEY,
+	label: 'External Project Name',
+	width: 260,
+}
 
 const internalProjectColumns: ColumnsType<FMSProject> = [
 	{
@@ -90,6 +98,14 @@ const ExternalProjectsPage = () => {
 	const [error, setError] = useState<string | null>(null)
 	const [filters, setFilters] = useState<FilterSet>({})
 
+	const setFilter = useCallback<SetFilterFunc>(
+	(filterKey, value, description) => {
+		setFilters((currentFilters) =>
+			setFilterValue(currentFilters, description, value)
+		)
+	},[],
+	)
+
 	const clearFilters = useCallback(() => {setFilters({})}, [])
 
 	const parentProjectColumns =useMemo<ColumnsType<FMSParentProject>>(()=> [
@@ -105,53 +121,11 @@ const ExternalProjectsPage = () => {
 			dataIndex: 'name',
 			key: 'external_project_name',
 			filteredValue: filters[EXTERNAL_PROJECT_NAME_FILTER_KEY]?.value ? [String(filters[EXTERNAL_PROJECT_NAME_FILTER_KEY].value)] : null,
-			filterIcon: (filtered: boolean) => <SearchOutlined style={{ color: filtered ? '#1890ff' : undefined }} />,
-			filterDropdown: ({ setSelectedKeys, selectedKeys, confirm, clearFilters }) => (
-				<div style={{ padding: 8 }}>
-					<Input
-						placeholder="Search External project name"
-						value={selectedKeys[0]}
-						onChange={(event) => setSelectedKeys(event.target.value ? [event.target.value] : [])}
-						onPressEnter={() => confirm()}
-						style={{ marginBottom: 8, display: 'block', width: 260 }}
-					/>
-					<Button
-						type="primary"
-						size="small"
-						onClick={() => {
-							const value = String(selectedKeys[0] || '')
-							setFilters( value ? {
-											[EXTERNAL_PROJECT_NAME_FILTER_KEY]: {
-												value,
-												description: {
-													type: 'INPUT',
-													key: EXTERNAL_PROJECT_NAME_FILTER_KEY,
-													label: 'External Project Name',
-												},
-											}  ,
-										}
-									: {},
-							)
-
-							confirm()
-						}}
-						style={{ width: 90, marginRight: 8 }}
-					>
-						Search
-					</Button>
-					<Button
-						size="small"
-						onClick={() => {
-							clearFilters?.()
-							setFilters({})
-							confirm()
-						}}
-						style={{ width: 90 }}
-					>
-						Reset
-					</Button>
-				</div>
-			),
+			...getFilterPropsForDescription(
+				EXTERNAL_PROJECT_NAME_FILTER_DESCRIPTION,
+				filters[EXTERNAL_PROJECT_NAME_FILTER_KEY],
+				setFilter,
+			),					
 			onFilter: (value, record) => (record.name || '').toLowerCase().includes(String(value).toLowerCase()),
 			render: (externalProjectName: string | null) => externalProjectName || '',
 		},
@@ -169,7 +143,7 @@ const ExternalProjectsPage = () => {
 				)
 			},
 		},
-	], [filters, setFilters])
+	], [filters, setFilter])
 
 	const dispatch = useAppDispatch()
 

--- a/frontend/src/components/projectOverview/ExternalProjectsPage.tsx
+++ b/frontend/src/components/projectOverview/ExternalProjectsPage.tsx
@@ -4,7 +4,7 @@ import type { ColumnsType } from 'antd/es/table'
 import React, { useCallback, useEffect, useState } from 'react'
 import AppPageHeader from '../AppPageHeader'
 import { Link } from 'react-router-dom'
-import { FMSProject } from '../../models/fms_api_models'
+import { FMSProject,FMSParentProject } from '../../models/fms_api_models'
 import api from '../../utils/api'
 
 import PageContent from '../PageContent'
@@ -14,7 +14,7 @@ import { SearchOutlined } from '@ant-design/icons'
 
 import FiltersBar from '../filters/filtersBar/FiltersBar'
 import { FilterSet } from '../../models/paged_items'
-import {FMSParentProject} from '../../models/fms_api_models'
+
 
 
 const EXTERNAL_PROJECT_NAME_FILTER_KEY = 'external_project_name'
@@ -215,12 +215,11 @@ const ExternalProjectsPage = () => {
 	}, [fetchProjectsByExternalID])
 
 	
-
 	return (
 		<>
 			<AppPageHeader title="Projects by External ID" />
 
-			{ <PageContent>
+			 <PageContent>
 				{error && (<Alert type="error" title={error} style={{ marginBottom: 16 }} />)}
 				<div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 8 }}>
 					<FiltersBar filters={filters} clearFilters={clearFilters} />
@@ -228,7 +227,7 @@ const ExternalProjectsPage = () => {
 				<Table
 					size="small"
 					bordered
-					rowKey={(parentProject) => parentProject.external_id || 'no-external-id'}
+					rowKey="id"
 					dataSource={parentProjects}
 					columns={parentProjectColumns}
 					loading={isLoading}
@@ -255,7 +254,7 @@ const ExternalProjectsPage = () => {
 						showTotal: (total, range) => `${range[0]}-${range[1]} of ${total} external IDs`,
 					}}
 				/>
-			</PageContent> }
+			</PageContent> 
 		</>
 	)
 }

--- a/frontend/src/components/projectOverview/ExternalProjectsPage.tsx
+++ b/frontend/src/components/projectOverview/ExternalProjectsPage.tsx
@@ -20,10 +20,18 @@ import { setFilterValue } from '../../models/filter_set_reducers'
 
 
 const EXTERNAL_PROJECT_NAME_FILTER_KEY = 'external_project_name'
+const EXTERNAL_PROJECT_ID_FILTER_KEY = 'external_project_id'
+
 const EXTERNAL_PROJECT_NAME_FILTER_DESCRIPTION: FilterDescription = {
 	type: 'INPUT',
 	key: EXTERNAL_PROJECT_NAME_FILTER_KEY,
 	label: 'External Project Name',
+	width: 260,
+}
+const EXTERNAL_PROJECT_ID_FILTER_DESCRIPTION: FilterDescription = {
+	type: 'INPUT',
+	key: EXTERNAL_PROJECT_ID_FILTER_KEY,
+	label: 'External Project ID',
 	width: 260,
 }
 
@@ -114,6 +122,16 @@ const ExternalProjectsPage = () => {
 			dataIndex: 'external_id',
 			key: 'external_id',
 			width: 120,
+			filteredValue: filters[EXTERNAL_PROJECT_ID_FILTER_KEY]?.value ? [String(filters[EXTERNAL_PROJECT_ID_FILTER_KEY].value)] : null,
+			...getFilterPropsForDescription(
+				EXTERNAL_PROJECT_ID_FILTER_DESCRIPTION,
+				filters[EXTERNAL_PROJECT_ID_FILTER_KEY],
+				setFilter,
+			),
+			onFilter: (value, record) =>
+				(record.external_id || '')
+					.toLowerCase()
+					.includes(String(value).toLowerCase()),
 			render: (externalID: string, parentProject: FMSParentProject) => (<Link to={`/external-projects-overview/${parentProject.id}#submissions`}>{externalID}</Link>)
 		},
 		{

--- a/frontend/src/components/projectOverview/ExternalProjectsPage.tsx
+++ b/frontend/src/components/projectOverview/ExternalProjectsPage.tsx
@@ -1,19 +1,264 @@
 
-import React from 'react'
-
+import { Alert, Button, Input, Table, Tag } from 'antd'
+import type { ColumnsType } from 'antd/es/table'
+import React, { useCallback, useEffect, useState } from 'react'
 import AppPageHeader from '../AppPageHeader'
+import { Link } from 'react-router-dom'
+import { FMSProject } from '../../models/fms_api_models'
+import api from '../../utils/api'
+
+import PageContent from '../PageContent'
+
+import { useAppDispatch } from '../../hooks'
+import { SearchOutlined } from '@ant-design/icons'
+
+import FiltersBar from '../filters/filtersBar/FiltersBar'
+import { FilterSet } from '../../models/paged_items'
+import {FMSParentProject} from '../../models/fms_api_models'
+
+
+const EXTERNAL_PROJECT_NAME_FILTER_KEY = 'external_project_name'
+
+const internalProjectColumns: ColumnsType<FMSProject> = [
+	{
+		title: 'ID',
+		dataIndex: 'id',
+		key: 'id',
+		render: (id: number) => <Link to={`/projects/${id}#overview`}>{id}</Link>,
+	},
+	{
+		title: 'Project Name',
+		dataIndex: 'name',
+		key: 'name',
+		render: (name: string, project: FMSProject) => <Link to={`/projects/${project.id}#overview`}>{name}</Link>,
+	},
+	{
+		title: 'Principal Investigator',
+		dataIndex: 'principal_investigator',
+		key: 'principal_investigator',
+	},
+	{
+		title: 'Requestor Name',
+		dataIndex: 'requestor_name',
+		key: 'requestor_name',
+	},
+	{
+		title: 'Status',
+		dataIndex: 'status',
+		key: 'status',
+	},
+	{
+		title: 'Created At',
+		dataIndex: 'created_at',
+		key: 'created_at',
+		render: (createdAt: string) =>  createdAt  ? 
+			new Date(createdAt).toLocaleDateString('en-US', 
+				{
+					month: 'short',
+					day: 'numeric',
+					year: 'numeric',
+				})
+				: '',
+	},
+]
 
 
 const ExternalProjectsPage = () => {
+	const [parentProjects, setParentProjects] = useState<FMSParentProject[]>([])
+	const [internalProjectsByID, setInternalProjectsByID] = useState<Partial<Record<number, FMSProject>>>({})
+
+	const [isLoading, setIsLoading] = useState(false)
+	const [error, setError] = useState<string | null>(null)
+	const [filters, setFilters] = useState<FilterSet>({})
+
+	const clearFilters = useCallback(() => {setFilters({})}, [])
+
+	const parentProjectColumns: ColumnsType<FMSParentProject> = [
+		{
+			title: 'External Project ID',
+			dataIndex: 'external_id',
+			key: 'external_id',
+			width: 120,
+			render: (externalID: string, parentProject: FMSParentProject) => (<Link to={`/external-projects-overview/${parentProject.id}#submissions`}>{externalID}</Link>)
+		},
+		{
+			title: 'External Project Name',
+			dataIndex: 'name',
+			key: 'external_project_name',
+			filteredValue: filters[EXTERNAL_PROJECT_NAME_FILTER_KEY]?.value ? [String(filters[EXTERNAL_PROJECT_NAME_FILTER_KEY].value)] : null,
+			filterIcon: (filtered: boolean) => <SearchOutlined style={{ color: filtered ? '#1890ff' : undefined }} />,
+			filterDropdown: ({ setSelectedKeys, selectedKeys, confirm, clearFilters }) => (
+				<div style={{ padding: 8 }}>
+					<Input
+						placeholder="Search External project name"
+						value={selectedKeys[0]}
+						onChange={(event) => setSelectedKeys(event.target.value ? [event.target.value] : [])}
+						onPressEnter={() => confirm()}
+						style={{ marginBottom: 8, display: 'block', width: 260 }}
+					/>
+					<Button
+						type="primary"
+						size="small"
+						onClick={() => {
+							const value = String(selectedKeys[0] || '')
+							setFilters( value ? {
+											[EXTERNAL_PROJECT_NAME_FILTER_KEY]: {
+												value,
+												description: {
+													type: 'INPUT',
+													key: EXTERNAL_PROJECT_NAME_FILTER_KEY,
+													label: 'External Project Name',
+												},
+											}  ,
+										}
+									: {},
+							)
+
+							confirm()
+						}}
+						style={{ width: 90, marginRight: 8 }}
+					>
+						Search
+					</Button>
+					<Button
+						size="small"
+						onClick={() => {
+							clearFilters?.()
+							setFilters({})
+							confirm()
+						}}
+						style={{ width: 90 }}
+					>
+						Reset
+					</Button>
+				</div>
+			),
+			onFilter: (value, record) => (record.name || '').toLowerCase().includes(String(value).toLowerCase()),
+			render: (externalProjectName: string | null) => externalProjectName || '',
+		},
+		{
+			title: 'Freezeman Projects',
+			dataIndex: 'projects',
+			key: 'projects',
+			width: 20,
+			render: (projects: FMSParentProject['projects']) => {
+				const projectCount = projects?.length ?? 0
+				return (
+					<Tag color={projectCount > 1 ? 'blue' : 'default'}>
+						{projectCount}
+					</Tag>
+				)
+			},
+		},
+	]
+
+	const dispatch = useAppDispatch()
+
+	const fetchProjectsByExternalID = useCallback(async () => {
+		try {
+			setIsLoading(true)
+			setError(null)
+
+			const response = await dispatch(
+				api.parentProjects.list({limit: 100000,ordering: 'external_id',},true,),
+			)
+			
+			const fetchedParentProjects = response.data.results
+			setParentProjects(fetchedParentProjects)
+
+			const internalProjectIDs = [
+                ...new Set(fetchedParentProjects.flatMap((parentProject) => parentProject.projects ?? [])),
+			]
+			
+
+			if (internalProjectIDs.length > 0) {
+    			const internalProjectsResponse = await dispatch(
+        		api.projects.list(
+            		{
+                		id__in: internalProjectIDs.join(','),
+                		limit: 100000,
+            		},
+            	true,
+        			),
+    			)
+
+    		const fetchedInternalProjects = internalProjectsResponse.data.results
+			
+			const fetchedInternalProjectsByID = fetchedInternalProjects.reduce<Partial<Record<number, FMSProject>>>(
+				(projectsByID, project) => {
+					projectsByID[project.id] = project
+					return projectsByID
+				}, {})
+
+			setInternalProjectsByID(fetchedInternalProjectsByID)
+			} 
+			else 
+			{
+    		    setInternalProjectsByID({})
+			}
+		} 
+		catch (error) {
+
+			if (error instanceof Error && error.name !== 'AbortError') {
+				setParentProjects([])
+				setInternalProjectsByID({})
+				setError('Unable to fetch projects by External ID')
+			}
+		} 
+		finally {
+			setIsLoading(false)
+		}
+	}, [dispatch])
+
+	useEffect(() => {
+		fetchProjectsByExternalID()
+	}, [fetchProjectsByExternalID])
+
 	
 
 	return (
 		<>
 			<AppPageHeader title="Projects by External ID" />
 
-			
+			{ <PageContent>
+				{error && (<Alert type="error" title={error} style={{ marginBottom: 16 }} />)}
+				<div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 8 }}>
+					<FiltersBar filters={filters} clearFilters={clearFilters} />
+				</div>
+				<Table
+					size="small"
+					bordered
+					rowKey={(parentProject) => parentProject.external_id || 'no-external-id'}
+					dataSource={parentProjects}
+					columns={parentProjectColumns}
+					loading={isLoading}
+					
+					expandable={{
+    					expandedRowRender: (parentProject) => {const internalProjects = (parentProject.projects ?? [])
+            				.map((projectID) => internalProjectsByID[projectID])
+							.filter((project): project is FMSProject =>project !== undefined)
+							return (
+								<Table
+									size="small"
+									rowKey="id"
+									dataSource={internalProjects}
+									columns={internalProjectColumns}
+									pagination={false}
+								/>
+							)
+                           },
+                    }}
+					pagination={{
+						pageSize: 20,
+						showSizeChanger: true,
+						pageSizeOptions: ['20', '50', '100'],
+						showTotal: (total, range) => `${range[0]}-${range[1]} of ${total} external IDs`,
+					}}
+				/>
+			</PageContent> }
 		</>
 	)
 }
 
 export default ExternalProjectsPage
+

--- a/frontend/src/components/projectOverview/ExternalProjectsPage.tsx
+++ b/frontend/src/components/projectOverview/ExternalProjectsPage.tsx
@@ -1,5 +1,5 @@
 
-import { Alert, Table, Tag } from 'antd'
+import { Table, Tag } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import AppPageHeader from '../AppPageHeader'
@@ -103,7 +103,6 @@ const ExternalProjectsPage = () => {
 	const [internalProjectsByID, setInternalProjectsByID] = useState<Partial<Record<number, FMSProject>>>({})
 
 	const [isLoading, setIsLoading] = useState(false)
-	const [error, setError] = useState<string | null>(null)
 	const [filters, setFilters] = useState<FilterSet>({})
 
 	const setFilter = useCallback<SetFilterFunc>(
@@ -202,7 +201,7 @@ const ExternalProjectsPage = () => {
 	const fetchParentProjectsWithInternalProjects = useCallback(async () => {
 		try {
 			setIsLoading(true)
-			setError(null)
+		
 
 			const fetchedParentProjects = await fetchParentProjects()
 			setParentProjects(fetchedParentProjects)
@@ -217,7 +216,7 @@ const ExternalProjectsPage = () => {
 			if (error instanceof Error && error.name !== 'AbortError') {
 				setParentProjects([])
 				setInternalProjectsByID({})
-				setError('Unable to fetch projects by External ID')
+			
 			}
 		} 
 		finally {
@@ -235,7 +234,6 @@ const ExternalProjectsPage = () => {
 			<AppPageHeader title="Projects by External ID" />
 
 			 <PageContent>
-				{error && (<Alert type="error" title={error} style={{ marginBottom: 16 }} />)}
 				<div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 8 }}>
 					<FiltersBar filters={filters} clearFilters={clearFilters} />
 				</div>

--- a/frontend/src/components/projectOverview/ExternalProjectsPage.tsx
+++ b/frontend/src/components/projectOverview/ExternalProjectsPage.tsx
@@ -132,7 +132,7 @@ const ExternalProjectsPage = () => {
 				(record.external_id || '')
 					.toLowerCase()
 					.includes(String(value).toLowerCase()),
-			render: (externalID: string, parentProject: FMSParentProject) => (<Link to={`/external-projects-overview/${parentProject.id}#submissions`}>{externalID}</Link>)
+			
 		},
 		{
 			title: 'External Project Name',


### PR DESCRIPTION
### Note
Please review #1178 first if you haven't already.

Adds a Parent Projects table displaying the list of external projects . Each external project is described with its external ID, name, and number of associated Freezeman projects. Each row can be expanded to show the corresponding internal projects and their key information. The page also supports filtering Parent Projects by external project name.

<img width="1909" height="1038" alt="image" src="https://github.com/user-attachments/assets/127f2e7f-b9c1-4a6b-87ac-51446b3390ec" />
